### PR TITLE
Update docker composeto use volumes with latest images.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     ports:
       - 8080:80
     volumes:
+      - drupal-files:/var/www/html/docroot/sites/default/files
       - ./:/var/www/html/docroot/themes/custom/madrone
     restart: unless-stopped
   database:
@@ -27,3 +28,4 @@ services:
 
 volumes:
   drupal-db:
+  drupal-files:


### PR DESCRIPTION
I've made updates to the image we are using for volumes and to ensure that the default user is www-data. These compose changes are in line with the latest version available on Docker Hub.