### PR TITLE
Fix for warnings when using Bulk Operations

### DIFF
--- a/madrone.theme
+++ b/madrone.theme
@@ -310,7 +310,7 @@ function madrone_theme_suggestions_form_alter(array &$suggestions, array $variab
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function madrone_theme_suggestions_form_element_alter(array &$suggestions, array $variables) {
-  if ($variables['element']['#id'] === 'admin-toolbar-search-input') {
+  if (array_key_exists('#id', $variables['element']) && $variables['element']['#id'] === 'admin-toolbar-search-input') {
     $suggestions[] = $variables['theme_hook_original'] . '__' . 'admin_toolbar_search';
   }
 }


### PR DESCRIPTION
Got warnings about an undefined array key when using bulk operations.