### PR TITLE
Add custom accessibility checks for specific link types

### DIFF
--- a/dist/madrone-editoria11y.js
+++ b/dist/madrone-editoria11y.js
@@ -1,0 +1,106 @@
+document.addEventListener('ed11yRunCustomTests', () => {
+
+  // 1. Write your custom test.
+  // This can be anything you want.
+  //
+  // This example uses Ed11y.findElements(),
+  // which respects checkRoots and ignoreElements,
+  // to find links with a particular string in their URL.
+  Ed11y.findElements('safeLinks', 'a[href*="safelinks.protection.outlook.com/?"]');
+
+  // Hard Dev links should be avoided.
+  Ed11y.findElements('devLinks', 'a[href*="dev.oregonstate.edu"]');
+
+  // 2. Create a message for your tooltip.
+  // You'll need a title and some contents,
+  // as a value for the key you create for your test.
+  //
+  // Be sure to use the same key as the test name below.
+  Ed11y.M.outlookSafeLink = {
+    title: 'URL is Safe Link encoded',
+    tip: (href) =>
+      `<p>The URL for this link has been copied from an email.
+              It includes the original recipient's email address,
+              and will bounce all clicks through the Outlook Safelinks server.</p>
+          <p>The specified URL is:<br>
+          <em style='word-break: break-all;font-size:90%;line-height: 1.2;display: block;'>
+             ${Ed11y.sanitizeForHTML(href)}
+          </em></p>
+          ${decodeSafelink(href)}
+          `,
+  };
+
+  Ed11y.M.devLink = {
+    title: 'URL is hard linking to Development site',
+    tip: (href) => `
+    <p>The URL for this link is using a full URL to the Development Site, Relative links should be used.</p>
+    <p>The specified URL is:<br>
+    <em>${Ed11y.sanitizeForHTML(href)}</em>
+    </p>
+    ${decodeDevLink(href)}
+    `,
+  };
+
+  // 3. Push each item you want flagged to Ed11y.results.
+  //
+  // You must provide:
+  //   el: The element
+  //   test: A key for your test
+  //   content: The tip you created above.
+  //   position: "beforebegin" for images and links,
+  //             "afterbegin" for paragraphs.
+  //   dismissalKey: false for errors,
+  //             a unique string for manual checks.
+  Ed11y.elements.safeLinks?.forEach((el) => {
+    Ed11y.results.push({
+      element: el,
+      test: 'outlookSafeLink',
+      content: Ed11y.M.outlookSafeLink.tip(el.getAttribute('href')),
+      position: 'beforebegin',
+      dismissalKey: false,
+    })
+  })
+
+  Ed11y.elements.devLinks?.forEach((el) => {
+    Ed11y.results.push({
+      element: el,
+      test: 'devLink',
+      content: Ed11y.M.devLink.tip(el.getAttribute('href')),
+      position: 'beforebegin',
+      dismissalKey: false,
+    })
+  })
+
+  // 4. When you are done with all your custom tests,
+  // dispatch an "ed11yResume" event:
+  let allDone = new CustomEvent('ed11yResume');
+  document.dispatchEvent(allDone);
+});
+
+/**
+ * Decodes a Safelink URL and returns the actual URL.
+ *
+ * @param {string} url - The Safelink URL to decode.
+ * @returns {string} - The actual URL, formatted as an HTML paragraph.
+ *                    If the Safelink URL does not contain a 'url' parameter, an empty string is returned.
+ */
+function decodeSafelink(url) {
+  const params = new URL(url).searchParams;
+  let decoded = params.get('url');
+  if (!!decoded) {
+    decoded = Ed11y.sanitizeForHTML(decoded);
+    return `<p>The actual URL may be:<br><em style='word-wrap: break-word;'>${decoded}</em></p>`
+  }
+  return '';
+}
+
+/**
+ * Decodes a developer link URL and returns the relative URL as a string.
+ *
+ * @param {string} url - The developer link URL to decode.
+ * @return {string} - The decoded relative URL.
+ */
+function decodeDevLink(url) {
+  const pathname = new URL(url).pathname;
+  return `<p>The relative URL may be:<br><em style='word-wrap: break-word;'>${Ed11y.sanitizeForHTML(pathname)}</em>`
+}

--- a/dist/madrone-editoria11y.js
+++ b/dist/madrone-editoria11y.js
@@ -22,38 +22,41 @@ document.addEventListener('ed11yRunCustomTests', () => {
   // Be sure to use the same key as the test name below.
   Ed11y.M.outlookSafeLink = {
     title: 'URL is Safe Link encoded',
-    tip: (href) =>
-      `<p>The URL for this link has been copied from an email.
-              It includes the original recipient's email address,
-              and will bounce all clicks through the Outlook Safelinks server.</p>
-          <p>The specified URL is:<br>
-          <em style='word-break: break-all;font-size:90%;line-height: 1.2;display: block;'>
-             ${Ed11y.sanitizeForHTML(href)}
-          </em></p>
-          ${decodeSafelink(href)}
-          `,
+    tip: (href) => `
+        <p>The URL for this link has been copied from an email. It includes the original recipient's email address,
+        and will bounce all clicks through the Outlook Safelinks server.
+         </p>
+        <p>The specified URL is:<br>
+            <em style='word-break: break-all;font-size:90%;line-height: 1.2;display: block;'>
+                ${Ed11y.sanitizeForHTML(href)}
+            </em>
+        </p>
+        ${decodeSafelink(href)}
+    `,
   }
 
   Ed11y.M.devLink = {
     title: 'URL is hard linking to Development site',
-    tip: (href) =>
-      `<p>The URL for this link is using a full URL to the Development Site, Relative links should be used.</p>
-       <p>The specified URL is:<br>
-        <em>${Ed11y.sanitizeForHTML(href)}</em>
-       </p>
-    ${getPathFromUrl(href)}`,
+    tip: (href) => `
+        <p>The URL for this link is using a full URL to the Development Site, Relative links should be used.</p>
+        <p>The specified URL is:<br>
+            <em>${Ed11y.sanitizeForHTML(href)}</em>
+        </p>
+        ${getPathFromUrl(href)}
+    `,
   }
 
   Ed11y.M.sameSiteFullLink = {
     title: 'Manual Check: did you mean to use a full link?',
-    tip: (href) =>
-      `<p>Using a Fully Qualified Domain Name when linking internally is discouraged.</p>
-       <p>The specified URL is:<br/>
-       <em>${Ed11y.sanitizeForHTML(href)}</em>
-       </p>
-       <p>Generally when linking to pages/files within the same site it is best to use the tools provided in the
+    tip: (href) => `
+        <p>Using a Fully Qualified Domain Name when linking internally is discouraged.</p>
+        <p>The specified URL is:<br/>
+            <em>${Ed11y.sanitizeForHTML(href)}</em>
+        </p>
+        <p>Generally when linking to pages/files within the same site it is best to use the tools provided in the
            content editor to generate links correctly.</p>
-        ${getPathFromUrl(href)}`,
+        ${getPathFromUrl(href)}
+    `,
   }
 
   // 3. Push each item you want flagged to Ed11y.results.

--- a/dist/madrone.js
+++ b/dist/madrone.js
@@ -9,133 +9,133 @@ let originalBreadcrumbs;
 let breadcrumbs;
 let condensedCrumbs;
 window.addEventListener('load', () => {
-    reducedMotionCheck();
-    const superfishMenus = [...document.querySelectorAll('ul.sf-menu')];
-    superfishMenus.map(menu => {
-        let menuId = menu.getAttribute('id');
-        let menuToggles = document.querySelectorAll(`a#${menuId}-toggle`);
-        [...menuToggles].map(menuToggle => {
-            menuToggle.addEventListener('click', event => {
-                menuClickedText(menuToggle);
-            })
-        })
-    });
+  reducedMotionCheck();
+  const superfishMenus = [...document.querySelectorAll('ul.sf-menu')];
+  superfishMenus.map(menu => {
+    let menuId = menu.getAttribute('id');
+    let menuToggles = document.querySelectorAll(`a#${menuId}-toggle`);
+    [...menuToggles].map(menuToggle => {
+      menuToggle.addEventListener('click', event => {
+        menuClickedText(menuToggle);
+      })
+    })
+  });
 
-    // Check on page load if we need to be a mobile menu.
-    if (window.innerWidth <= 768) {
-        groupMobileMenu();
-        const groupMenu = document.querySelector('#group-content-menu');
-        if (groupMenu) {
-            groupMenu.classList.add('d-none');
-        }
-
-        mobileBreadcrumbs();
+  // Check on page load if we need to be a mobile menu.
+  if (window.innerWidth <= 768) {
+    groupMobileMenu();
+    const groupMenu = document.querySelector('#group-content-menu');
+    if (groupMenu) {
+      groupMenu.classList.add('d-none');
     }
 
-    // handle group menu horizontal spacing
-    const groupMenus = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li ul')];
-    groupMenus.forEach(menu => {
-        resizeMenu(menu);
-        if (!menu.classList.contains('menu--level-2')) {
-            // move the child element 100% of its width.
-            menu.style.left = '100%';
-        }
+    mobileBreadcrumbs();
+  }
+
+  // handle group menu horizontal spacing
+  const groupMenus = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li ul')];
+  groupMenus.forEach(menu => {
+    resizeMenu(menu);
+    if (!menu.classList.contains('menu--level-2')) {
+      // move the child element 100% of its width.
+      menu.style.left = '100%';
+    }
+  });
+
+  // this must come after groupMobileMenu() since .menu--level-1 changes there
+  const liList = [...document.querySelectorAll('.block-group-content-menu .menu--level-1 li')];
+  liList.forEach(li => {
+    // if li has child ul element
+    if ([...(li.children)].some(e => e.tagName === 'UL')) {
+      // add class chevron icon
+      li.classList.add('group-sub-menu');
+    }
+  });
+
+  // Add event listeners only for desktop.
+  const desktopMenuLiList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li')];
+  desktopMenuLiList.forEach(desktopLi => {
+    desktopLi.addEventListener('mouseenter', menuItemHoverEvent);
+    desktopLi.addEventListener('focusin', menuItemFocusinEvent);
+    desktopLi.addEventListener('mouseleave', menuItemMouseLeaveEvent);
+    desktopLi.addEventListener('focusout', menuItemMouseLeaveEvent);
+  });
+
+  // Add an overflow hidden class to the parent element if the block is inside a column class and has animations.
+  const animatedBlocks = [...document.querySelectorAll(".block.aos-init")];
+  animatedBlocks.map(block => {
+    let blockParent = block.parentElement;
+    for (let i = 0; i < blockParent.classList.length; i++) {
+      if (/col-.*/.test(blockParent.classList[i])) {
+        blockParent.classList.add('overflow-hidden');
+        break;
+      }
+    }
+  });
+
+  // ToCJS Width setter.
+  const tocJsBlocks = document.querySelectorAll(".toc-js");
+  if (tocJsBlocks.length > 0) {
+    let tocJsBlock = tocJsBlocks[0];
+    let tocJsParentBlock = tocJsBlock.closest('.block[class*="toc-js"]');
+    const tocJsParentBlockStyle = window.getComputedStyle(tocJsParentBlock);
+
+    resizeTocJsBlock(tocJsBlock);
+
+    let prevClassState = tocJsBlock.classList.contains('is-sticked');
+    // We only care about background, border, and padding.
+    let classesToCopy = [...tocJsParentBlockStyle].filter((key) => {
+      if (/^border.*/.test(key) || /^background.*/.test(key) || /^padding.*/.test(key)) {
+        return key;
+      }
     });
-
-    // this must come after groupMobileMenu() since .menu--level-1 changes there
-    const liList = [...document.querySelectorAll('.block-group-content-menu .menu--level-1 li')];
-    liList.forEach(li => {
-        // if li has child ul element
-        if ([...(li.children)].some(e => e.tagName === 'UL')) {
-            // add class chevron icon
-            li.classList.add('group-sub-menu');
-        }
-    });
-
-    // Add event listeners only for desktop.
-    const desktopMenuLiList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li')];
-    desktopMenuLiList.forEach(desktopLi => {
-        desktopLi.addEventListener('mouseenter', menuItemHoverEvent);
-        desktopLi.addEventListener('focusin', menuItemFocusinEvent);
-        desktopLi.addEventListener('mouseleave', menuItemMouseLeaveEvent);
-        desktopLi.addEventListener('focusout', menuItemMouseLeaveEvent);
-    });
-
-    // Add an overflow hidden class to the parent element if the block is inside a column class and has animations.
-    const animatedBlocks = [...document.querySelectorAll(".block.aos-init")];
-    animatedBlocks.map(block => {
-        let blockParent = block.parentElement;
-        for (let i = 0; i < blockParent.classList.length; i++) {
-            if (/col-.*/.test(blockParent.classList[i])) {
-                blockParent.classList.add('overflow-hidden');
-                break;
-            }
-        }
-    });
-
-    // ToCJS Width setter.
-    const tocJsBlocks = document.querySelectorAll(".toc-js");
-    if (tocJsBlocks.length > 0) {
-        let tocJsBlock = tocJsBlocks[0];
-        let tocJsParentBlock = tocJsBlock.closest('.block[class*="toc-js"]');
-        const tocJsParentBlockStyle = window.getComputedStyle(tocJsParentBlock);
-
-        resizeTocJsBlock(tocJsBlock);
-
-        let prevClassState = tocJsBlock.classList.contains('is-sticked');
-        // We only care about background, border, and padding.
-        let classesToCopy = [...tocJsParentBlockStyle].filter((key) => {
-            if (/^border.*/.test(key) || /^background.*/.test(key) || /^padding.*/.test(key)) {
-                return key;
-            }
-        });
-        // We loaded the page not at the top, so we need to copy styles down.
-        if (prevClassState) {
+    // We loaded the page not at the top, so we need to copy styles down.
+    if (prevClassState) {
+      classesToCopy.forEach(cssClass => {
+        tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
+      });
+      // overwrite background color and border options when loading the page midway.
+      tocJsParentBlock.style.setProperty('background-color', 'transparent', 'important');
+      tocJsParentBlock.style.setProperty('border', '0', 'important');
+    }
+    // Create a mutation observer to watch for changes, specifically when the class 'is-sticked' is added/removed.
+    let tocJsObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.attributeName === 'class') {
+          let currentClassState = mutation.target.classList.contains('is-sticked');
+          if (prevClassState !== currentClassState) {
+            prevClassState = currentClassState;
+          }
+          if (prevClassState) {
             classesToCopy.forEach(cssClass => {
-                tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
+              tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
             });
-            // overwrite background color and border options when loading the page midway.
+            // Set the margin left and to stop the block from jumping and set the background to transparent on the
+            // parent block to "hide" it when scrolled.
+            tocJsParentBlock.style.setProperty('margin-left', `-${tocJsParentBlockStyle.paddingLeft}`, 'important')
             tocJsParentBlock.style.setProperty('background-color', 'transparent', 'important');
             tocJsParentBlock.style.setProperty('border', '0', 'important');
-        }
-        // Create a mutation observer to watch for changes, specifically when the class 'is-sticked' is added/removed.
-        let tocJsObserver = new MutationObserver(mutations => {
-            mutations.forEach(mutation => {
-                if (mutation.attributeName === 'class') {
-                    let currentClassState = mutation.target.classList.contains('is-sticked');
-                    if (prevClassState !== currentClassState) {
-                        prevClassState = currentClassState;
-                    }
-                    if (prevClassState) {
-                        classesToCopy.forEach(cssClass => {
-                            tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
-                        });
-                        // Set the margin left and to stop the block from jumping and set the background to transparent on the
-                        // parent block to "hide" it when scrolled.
-                        tocJsParentBlock.style.setProperty('margin-left', `-${tocJsParentBlockStyle.paddingLeft}`, 'important')
-                        tocJsParentBlock.style.setProperty('background-color', 'transparent', 'important');
-                        tocJsParentBlock.style.setProperty('border', '0', 'important');
-                    } else {
-                        classesToCopy.forEach(cssClass => {
-                            tocJsBlock.style.removeProperty(cssClass);
-                        });
-                        // Clear all classes we set.
-                        tocJsParentBlock.style.removeProperty('background-color');
-                        tocJsParentBlock.style.removeProperty('border');
-                        tocJsParentBlock.style.removeProperty('margin-left');
-                    }
-                }
+          } else {
+            classesToCopy.forEach(cssClass => {
+              tocJsBlock.style.removeProperty(cssClass);
             });
-        });
-        tocJsObserver.observe(tocJsBlock, {attributes: true, childList: false, characterData: false});
-    }
-    /* Simple Popup Blocks Module.
-     * Set Inline CSS Variables for margin-left.
-     */
-    document.querySelectorAll('.simple-popup-blocks-global .spb-popup-main-wrapper').forEach(osuSpb => {
-        osuSpb.style.setProperty('--spb-width', osuSpb.style.getPropertyValue('width'));
-        osuSpb.style.setProperty('--spb-margin-left', osuSpb.style.getPropertyValue('margin-left'));
-    })
+            // Clear all classes we set.
+            tocJsParentBlock.style.removeProperty('background-color');
+            tocJsParentBlock.style.removeProperty('border');
+            tocJsParentBlock.style.removeProperty('margin-left');
+          }
+        }
+      });
+    });
+    tocJsObserver.observe(tocJsBlock, {attributes: true, childList: false, characterData: false});
+  }
+  /* Simple Popup Blocks Module.
+   * Set Inline CSS Variables for margin-left.
+   */
+  document.querySelectorAll('.simple-popup-blocks-global .spb-popup-main-wrapper').forEach(osuSpb => {
+    osuSpb.style.setProperty('--spb-width', osuSpb.style.getPropertyValue('width'));
+    osuSpb.style.setProperty('--spb-margin-left', osuSpb.style.getPropertyValue('margin-left'));
+  })
 });
 
 /**
@@ -143,33 +143,33 @@ window.addEventListener('load', () => {
  * @param sfToggle
  */
 function menuClickedText(sfToggle) {
-    if (sfToggle.classList.contains('sf-expanded')) {
-        let menuToggleText = sfToggle.innerHTML;
-        sfToggle.innerHTML = `<span class="madrone-mobile-menu-close">Close&nbsp;</span>${menuToggleText}`
-    } else {
-        sfToggle.querySelector('span.madrone-mobile-menu-close').remove()
-    }
+  if (sfToggle.classList.contains('sf-expanded')) {
+    let menuToggleText = sfToggle.innerHTML;
+    sfToggle.innerHTML = `<span class="madrone-mobile-menu-close">Close&nbsp;</span>${menuToggleText}`
+  } else {
+    sfToggle.querySelector('span.madrone-mobile-menu-close').remove()
+  }
 }
 
 /**
  * Create the mobile menu cloning the exiting menu.
  */
 function groupMobileMenu() {
-    // Create menu top level bucket
-    const menus = document.querySelectorAll('ul#group-content-menu');
-    menus.forEach((menu) => {
-        createMenuBucket(menu);
-    });
+  // Create menu top level bucket
+  const menus = document.querySelectorAll('ul#group-content-menu');
+  menus.forEach((menu) => {
+    createMenuBucket(menu);
+  });
 
-    const liList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu-accordion .menu--level-1 li')];
-    liList.forEach(li => {
-        // if li has child ul element
-        if ([...(li.children)].some(e => e.tagName === 'UL')) {
-            cloneLi(li);
+  const liList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu-accordion .menu--level-1 li')];
+  liList.forEach(li => {
+    // if li has child ul element
+    if ([...(li.children)].some(e => e.tagName === 'UL')) {
+      cloneLi(li);
 
-            li.children[0].addEventListener('click', menuItemClickEvent);
-        }
-    });
+      li.children[0].addEventListener('click', menuItemClickEvent);
+    }
+  });
 }
 
 /**
@@ -177,30 +177,30 @@ function groupMobileMenu() {
  * @param menu
  */
 function createMenuBucket(menu) {
-    // Do a deep clone cleaning all extra styles.
-    const deepMenuClone = cleanDeepClone(menu);
-    // Create new top level ul.
-    const topUl = document.createElement('ul');
-    topUl.id = 'group-content-menu-accordion';
-    topUl.classList = menu.classList;
-    topUl.classList.remove('menu--level-1');
-    topUl.classList.add('menu--level-0', 'group-mobile-menu');
+  // Do a deep clone cleaning all extra styles.
+  const deepMenuClone = cleanDeepClone(menu);
+  // Create new top level ul.
+  const topUl = document.createElement('ul');
+  topUl.id = 'group-content-menu-accordion';
+  topUl.classList = menu.classList;
+  topUl.classList.remove('menu--level-1');
+  topUl.classList.add('menu--level-0', 'group-mobile-menu');
 
-    const topLi = document.createElement('li');
-    topLi.classList = menu.children[0].classList;
+  const topLi = document.createElement('li');
+  topLi.classList = menu.children[0].classList;
 
-    const topA = document.createElement('a');
-    topA.classList = menu.children[0].children[0].classList;
-    topA.classList.add('group-mobile-main-a');
-    topA.innerHTML = 'Menu';
+  const topA = document.createElement('a');
+  topA.classList = menu.children[0].children[0].classList;
+  topA.classList.add('group-mobile-main-a');
+  topA.innerHTML = 'Menu';
 
-    topLi.appendChild(topA);
-    topUl.appendChild(topLi);
-    menu.parentNode.insertBefore(topUl, menu);
-    // Append the cloned menu so we can target it with hide/show.
-    topLi.appendChild(deepMenuClone);
+  topLi.appendChild(topA);
+  topUl.appendChild(topLi);
+  menu.parentNode.insertBefore(topUl, menu);
+  // Append the cloned menu so we can target it with hide/show.
+  topLi.appendChild(deepMenuClone);
 
-    topA.addEventListener('click', menuItemClickEvent);
+  topA.addEventListener('click', menuItemClickEvent);
 }
 
 /**
@@ -209,13 +209,13 @@ function createMenuBucket(menu) {
  * @returns Node
  */
 function cleanDeepClone(menu) {
-    const deepClone = menu.cloneNode(true);
-    deepClone.removeAttribute("id");
-    const deepCloneSubMenus = deepClone.querySelectorAll('ul');
-    deepCloneSubMenus.forEach(deepCloneSubMenu => {
-        deepCloneSubMenu.style.left = null;
-    })
-    return deepClone;
+  const deepClone = menu.cloneNode(true);
+  deepClone.removeAttribute("id");
+  const deepCloneSubMenus = deepClone.querySelectorAll('ul');
+  deepCloneSubMenus.forEach(deepCloneSubMenu => {
+    deepCloneSubMenu.style.left = null;
+  })
+  return deepClone;
 }
 
 /**
@@ -223,20 +223,20 @@ function cleanDeepClone(menu) {
  * @param event
  */
 function menuItemClickEvent(event) {
-    // prevent clicks from navigating to the html <a> element.
-    event.preventDefault();
+  // prevent clicks from navigating to the html <a> element.
+  event.preventDefault();
 
-    // add styling and change text when clicked
-    if (this.parentNode.classList.contains('group-menu-clicked')) {
-        this.parentNode.classList.remove('group-menu-clicked');
+  // add styling and change text when clicked
+  if (this.parentNode.classList.contains('group-menu-clicked')) {
+    this.parentNode.classList.remove('group-menu-clicked');
 
-        this.textContent = this.textContent.replace('Close ', '');
-    } else {
-        this.parentNode.classList.add('group-menu-clicked');
+    this.textContent = this.textContent.replace('Close ', '');
+  } else {
+    this.parentNode.classList.add('group-menu-clicked');
 
-        const menuToggleText = this.textContent;
-        this.textContent = `Close ${menuToggleText}`;
-    }
+    const menuToggleText = this.textContent;
+    this.textContent = `Close ${menuToggleText}`;
+  }
 }
 
 /**
@@ -244,38 +244,38 @@ function menuItemClickEvent(event) {
  * @param event
  */
 function menuItemHoverEvent(event) {
-    if (this.classList.contains('group-menu-hover') && this.mouseLeaveTimeout) {
-        // prevent menu from hiding if the mouse leaves only for a moment
-        clearTimeout(this.mouseLeaveTimeout);
-    } else {
-        // If the menu might open off-screen move it, so it won't overflow.
-        // Get the Window Width.
-        const windowWidth = window.innerWidth;
-        // The full size of the menu item, this is the li.
-        const menuWidth = this.offsetWidth;
-        // Find the next UL in the menu tree down.
-        const menuChild = this.querySelector('ul');
-        if (menuChild) {
-            // Get the Full width of the new child menu item.
-            const menuChildWidth = menuChild.offsetWidth;
-            // Calculate how far right the new menu item might go.
-            const menuRight = menuChildWidth + menuChild.getBoundingClientRect().left;
-            // Ensure that the menu item will not go beyond the screen size.
-            if (menuRight > (windowWidth + window.scrollX)) {
-                if (menuChild.classList.contains('menu--level-2')) {
-                    // Let's set the first nested menu to line up with the parents right side.
-                    const menuParentRight = menuChild.closest('li').getBoundingClientRect().right;
-                    menuChild.style.left = 'auto';
-                    menuChild.style.right = `${windowWidth-menuParentRight}px`;
+  if (this.classList.contains('group-menu-hover') && this.mouseLeaveTimeout) {
+    // prevent menu from hiding if the mouse leaves only for a moment
+    clearTimeout(this.mouseLeaveTimeout);
+  } else {
+    // If the menu might open off-screen move it, so it won't overflow.
+    // Get the Window Width.
+    const windowWidth = window.innerWidth;
+    // The full size of the menu item, this is the li.
+    const menuWidth = this.offsetWidth;
+    // Find the next UL in the menu tree down.
+    const menuChild = this.querySelector('ul');
+    if (menuChild) {
+      // Get the Full width of the new child menu item.
+      const menuChildWidth = menuChild.offsetWidth;
+      // Calculate how far right the new menu item might go.
+      const menuRight = menuChildWidth + menuChild.getBoundingClientRect().left;
+      // Ensure that the menu item will not go beyond the screen size.
+      if (menuRight > (windowWidth + window.scrollX)) {
+        if (menuChild.classList.contains('menu--level-2')) {
+          // Let's set the first nested menu to line up with the parents right side.
+          const menuParentRight = menuChild.closest('li').getBoundingClientRect().right;
+          menuChild.style.left = 'auto';
+          menuChild.style.right = `${windowWidth - menuParentRight}px`;
 
-                } else {
-                    menuChild.style.left = `-${menuChildWidth}px`;
-                    menuChild.style.right = 'auto';
-                }
-            }
+        } else {
+          menuChild.style.left = `-${menuChildWidth}px`;
+          menuChild.style.right = 'auto';
         }
-        this.classList.add('group-menu-hover');
+      }
     }
+    this.classList.add('group-menu-hover');
+  }
 }
 
 /**
@@ -283,9 +283,9 @@ function menuItemHoverEvent(event) {
  * @param event
  */
 function menuItemFocusinEvent(event) {
-    if (!this.classList.contains('group-menu-hover')) {
-        this.classList.add('group-menu-hover');
-    }
+  if (!this.classList.contains('group-menu-hover')) {
+    this.classList.add('group-menu-hover');
+  }
 }
 
 /**
@@ -293,18 +293,18 @@ function menuItemFocusinEvent(event) {
  * @param event
  */
 function menuItemMouseLeaveEvent(event) {
-    const groupMenu = document.querySelectorAll('.block-group-content-menu')[0];
-    if (this.classList.contains('group-menu-hover') && !event.currentTarget.contains(event.relatedTarget)) {
-        // remove hover immediately if next target is still in the menu
-        // otherwise wait a bit
-        if (groupMenu.contains(event.relatedTarget)) {
-            this.classList.remove('group-menu-hover');
-        } else {
-            this.mouseLeaveTimeout = setTimeout(() => {
-                this.classList.remove('group-menu-hover');
-            }, 800);
-        }
+  const groupMenu = document.querySelectorAll('.block-group-content-menu')[0];
+  if (this.classList.contains('group-menu-hover') && !event.currentTarget.contains(event.relatedTarget)) {
+    // remove hover immediately if next target is still in the menu
+    // otherwise wait a bit
+    if (groupMenu.contains(event.relatedTarget)) {
+      this.classList.remove('group-menu-hover');
+    } else {
+      this.mouseLeaveTimeout = setTimeout(() => {
+        this.classList.remove('group-menu-hover');
+      }, 800);
     }
+  }
 }
 
 /**
@@ -312,10 +312,10 @@ function menuItemMouseLeaveEvent(event) {
  * @param li
  */
 function cloneLi(li) {
-    const clonedA = li.children[0].cloneNode(true);
-    const clonedLi = document.createElement('li');
-    clonedLi.appendChild(clonedA);
-    li.children[1].prepend(clonedLi);
+  const clonedA = li.children[0].cloneNode(true);
+  const clonedLi = document.createElement('li');
+  clonedLi.appendChild(clonedA);
+  li.children[1].prepend(clonedLi);
 }
 
 /**
@@ -323,49 +323,49 @@ function cloneLi(li) {
  * @returns {RegExpMatchArray}
  */
 function isMobile() {
-    return navigator.userAgent.match(/(android|bb\d+|meego)|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i);
+  return navigator.userAgent.match(/(android|bb\d+|meego)|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i);
 }
 
 // Add event listener to browser resize.
 window.addEventListener('resize', (event) => {
-    const tocJsBlocks = document.querySelectorAll(".toc-js");
-    if (tocJsBlocks.length > 0) {
-        const tocJsBlock = tocJsBlocks[0];
-        clearTimeout(tocJsTimeout);
-        tocJsTimeout = setTimeout(resizeTocJsBlock(tocJsBlock), DELAY);
-    }
-    if (window.innerWidth <= 768) {
-        // only add mobile menu if it doesn't already exist.
-        let groupMobileId = document.querySelector('#group-content-menu-accordion');
-        let groupMenuId = document.querySelector('#group-content-menu');
-        if (groupMobileId === null) {
-            groupMobileMenu();
-            if (groupMenuId) {
-                groupMenuId.classList.add('d-none');
-            }
-        } else {
-
-            groupMenuId.classList.add('d-none');
-            groupMobileId.classList.remove('d-none');
-            groupMobileId.classList.add('d-flex');
-        }
-
-        mobileBreadcrumbs();
+  const tocJsBlocks = document.querySelectorAll(".toc-js");
+  if (tocJsBlocks.length > 0) {
+    const tocJsBlock = tocJsBlocks[0];
+    clearTimeout(tocJsTimeout);
+    tocJsTimeout = setTimeout(resizeTocJsBlock(tocJsBlock), DELAY);
+  }
+  if (window.innerWidth <= 768) {
+    // only add mobile menu if it doesn't already exist.
+    let groupMobileId = document.querySelector('#group-content-menu-accordion');
+    let groupMenuId = document.querySelector('#group-content-menu');
+    if (groupMobileId === null) {
+      groupMobileMenu();
+      if (groupMenuId) {
+        groupMenuId.classList.add('d-none');
+      }
     } else {
-        // add back desktop menu if mobile menu was added.
-        let groupMobileId = document.querySelector('#group-content-menu-accordion');
-        let groupMenuId = document.querySelector('#group-content-menu');
-        if (groupMobileId !== null) {
-            groupMobileId.classList.remove('d-flex');
-            groupMobileId.classList.add('d-none');
-            groupMenuId.classList.remove('d-none');
-            groupMenuId.classList.add('d-flex');
-        }
 
-        if (condensedCrumbs) {
-            resetBreadCrumbs();
-        }
+      groupMenuId.classList.add('d-none');
+      groupMobileId.classList.remove('d-none');
+      groupMobileId.classList.add('d-flex');
     }
+
+    mobileBreadcrumbs();
+  } else {
+    // add back desktop menu if mobile menu was added.
+    let groupMobileId = document.querySelector('#group-content-menu-accordion');
+    let groupMenuId = document.querySelector('#group-content-menu');
+    if (groupMobileId !== null) {
+      groupMobileId.classList.remove('d-flex');
+      groupMobileId.classList.add('d-none');
+      groupMenuId.classList.remove('d-none');
+      groupMenuId.classList.add('d-flex');
+    }
+
+    if (condensedCrumbs) {
+      resetBreadCrumbs();
+    }
+  }
 });
 
 /**
@@ -373,21 +373,21 @@ window.addEventListener('resize', (event) => {
  * @param menu
  */
 function resizeMenu(menu) {
-    menu.style.width = "auto";
-    let menuUlMaxLength = 0;
-    menu.querySelectorAll('li').forEach(menuLi => {
-        menuLi.setAttribute('style', 'white-space:nowrap;');
-        let largestItem = Math.ceil(menuLi.clientWidth / fontSize);
-        if (largestItem < smallestEm) {
-            menuUlMaxLength = smallestEm;
-        } else if (largestItem > largestEm) {
-            menuUlMaxLength = largestEm;
-        } else {
-            menuUlMaxLength = largestItem + 1;
-        }
-        menuLi.setAttribute('style', '');
-    });
-    menu.style.width = `${menuUlMaxLength}em`;
+  menu.style.width = "auto";
+  let menuUlMaxLength = 0;
+  menu.querySelectorAll('li').forEach(menuLi => {
+    menuLi.setAttribute('style', 'white-space:nowrap;');
+    let largestItem = Math.ceil(menuLi.clientWidth / fontSize);
+    if (largestItem < smallestEm) {
+      menuUlMaxLength = smallestEm;
+    } else if (largestItem > largestEm) {
+      menuUlMaxLength = largestEm;
+    } else {
+      menuUlMaxLength = largestItem + 1;
+    }
+    menuLi.setAttribute('style', '');
+  });
+  menu.style.width = `${menuUlMaxLength}em`;
 }
 
 /**
@@ -397,46 +397,46 @@ function resizeMenu(menu) {
  * @return boolean
  */
 function resizeTocJsBlock(block) {
-    let closestParentBlock = block.closest('.block[class*="toc-js"]');
-    const parentBlockStyle = window.getComputedStyle(closestParentBlock);
-    const finalPadding = parseFloat(parentBlockStyle.paddingLeft) + parseFloat(parentBlockStyle.paddingRight);
-    const finalMargin = parseFloat(parentBlockStyle.marginLeft) + parseFloat(parentBlockStyle.marginRight);
-    const finalWidth = closestParentBlock.clientWidth - finalMargin - finalPadding;
-    block.style.width = `${finalWidth}px`;
-    return true;
+  let closestParentBlock = block.closest('.block[class*="toc-js"]');
+  const parentBlockStyle = window.getComputedStyle(closestParentBlock);
+  const finalPadding = parseFloat(parentBlockStyle.paddingLeft) + parseFloat(parentBlockStyle.paddingRight);
+  const finalMargin = parseFloat(parentBlockStyle.marginLeft) + parseFloat(parentBlockStyle.marginRight);
+  const finalWidth = closestParentBlock.clientWidth - finalMargin - finalPadding;
+  block.style.width = `${finalWidth}px`;
+  return true;
 }
 
 /**
  * Condense breadcrumbs list when >= 3 pages deep
  */
 function mobileBreadcrumbs() {
-    if (!breadcrumbs) {
-        breadcrumbs = document.querySelector('nav ol.breadcrumb');
-        if (breadcrumbs !== null) {
-            originalBreadcrumbs = breadcrumbs.cloneNode(true);
-            truncateCrumbs();
+  if (!breadcrumbs) {
+    breadcrumbs = document.querySelector('nav ol.breadcrumb');
+    if (breadcrumbs !== null) {
+      originalBreadcrumbs = breadcrumbs.cloneNode(true);
+      truncateCrumbs();
+    }
+  }
+  if (!originalBreadcrumbs && breadcrumbs !== null) {
+    originalBreadcrumbs = breadcrumbs.cloneNode(true);
+  }
+  if (breadcrumbs) {
+    const numCrumbs = breadcrumbs.children.length;
+    if (numCrumbs >= 3) {
+      if (!condensedCrumbs) {
+        createCondensedCrumbs(breadcrumbs);
+      } else {
+        // if originalBreadCrumbs has a parentNode then it is in the DOM, if not breadcrumbs is in DOM
+        if (originalBreadcrumbs.parentNode) {
+          originalBreadcrumbs.after(condensedCrumbs);
+          originalBreadcrumbs.remove();
+        } else {
+          breadcrumbs.after(condensedCrumbs);
         }
+      }
+      breadcrumbs.remove();
     }
-    if (!originalBreadcrumbs && breadcrumbs !== null) {
-        originalBreadcrumbs = breadcrumbs.cloneNode(true);
-    }
-    if (breadcrumbs) {
-        const numCrumbs = breadcrumbs.children.length;
-        if (numCrumbs >= 3) {
-            if (!condensedCrumbs) {
-                createCondensedCrumbs(breadcrumbs);
-            } else {
-                // if originalBreadCrumbs has a parentNode then it is in the DOM, if not breadcrumbs is in DOM
-                if (originalBreadcrumbs.parentNode) {
-                    originalBreadcrumbs.after(condensedCrumbs);
-                    originalBreadcrumbs.remove();
-                } else {
-                    breadcrumbs.after(condensedCrumbs);
-                }
-            }
-            breadcrumbs.remove();
-        }
-    }
+  }
 }
 
 /**
@@ -445,14 +445,14 @@ function mobileBreadcrumbs() {
  * @param {<ol> of breadcrumbs} breadcrumbs
  */
 function truncateCrumbs() {
-    const TEXT_LIMIT = 30;
-    [...breadcrumbs.children].forEach(crumb => {
-        if (crumb.children[0] && crumb.children[0].textContent.length > TEXT_LIMIT) {
-            crumb.children[0].textContent = `${crumb.children[0].textContent.substring(0, TEXT_LIMIT)}...`;
-        } else if (crumb.children.length === 0 && crumb.textContent.trim().length > TEXT_LIMIT) {
-            crumb.textContent = `${crumb.textContent.trim().substring(0, TEXT_LIMIT)}...`;
-        }
-    });
+  const TEXT_LIMIT = 30;
+  [...breadcrumbs.children].forEach(crumb => {
+    if (crumb.children[0] && crumb.children[0].textContent.length > TEXT_LIMIT) {
+      crumb.children[0].textContent = `${crumb.children[0].textContent.substring(0, TEXT_LIMIT)}...`;
+    } else if (crumb.children.length === 0 && crumb.textContent.trim().length > TEXT_LIMIT) {
+      crumb.textContent = `${crumb.textContent.trim().substring(0, TEXT_LIMIT)}...`;
+    }
+  });
 }
 
 /**
@@ -461,29 +461,29 @@ function truncateCrumbs() {
  * @param {<ol> of breadcrumbs} breadcrumbs
  */
 function createCondensedCrumbs(breadcrumbs) {
-    condensedCrumbs = document.createElement('ol');
-    condensedCrumbs.classList = ['breadcrumb breadcrumb-condensed'];
-    condensedCrumbs.appendChild(breadcrumbs.children[breadcrumbs.children.length - 2].cloneNode(true));
+  condensedCrumbs = document.createElement('ol');
+  condensedCrumbs.classList = ['breadcrumb breadcrumb-condensed'];
+  condensedCrumbs.appendChild(breadcrumbs.children[breadcrumbs.children.length - 2].cloneNode(true));
 
-    const expandCrumb = createCrumb('(expand)', breadcrumbs.children[0].classList, expandBreadCrumbs);
-    condensedCrumbs.children[0].before(expandCrumb);
-    const condenseCrumb = createCrumb('(condense)', [], condenseBreadCrumbs);
-    breadcrumbs.appendChild(condenseCrumb);
+  const expandCrumb = createCrumb('(expand)', breadcrumbs.children[0].classList, expandBreadCrumbs);
+  condensedCrumbs.children[0].before(expandCrumb);
+  const condenseCrumb = createCrumb('(condense)', [], condenseBreadCrumbs);
+  breadcrumbs.appendChild(condenseCrumb);
 
-    breadcrumbs.after(condensedCrumbs)
+  breadcrumbs.after(condensedCrumbs)
 }
 
 function createCrumb(textContent, classList, onclick) {
-    const crumb = document.createElement('li');
-    crumb.classList = classList;
+  const crumb = document.createElement('li');
+  crumb.classList = classList;
 
-    // create <a> tag with onclick event
-    crumb.appendChild(document.createElement('a'));
-    crumb.children[0].textContent = textContent;
-    crumb.children[0].href = '';
-    crumb.children[0].onclick = onclick;
+  // create <a> tag with onclick event
+  crumb.appendChild(document.createElement('a'));
+  crumb.children[0].textContent = textContent;
+  crumb.children[0].href = '';
+  crumb.children[0].onclick = onclick;
 
-    return crumb;
+  return crumb;
 }
 
 /**
@@ -492,13 +492,13 @@ function createCrumb(textContent, classList, onclick) {
  * @param {event} e click event
  */
 function expandBreadCrumbs(e) {
-    // not always called from an event
-    if (e) {
-        e.preventDefault();
-    }
+  // not always called from an event
+  if (e) {
+    e.preventDefault();
+  }
 
-    condensedCrumbs.after(breadcrumbs);
-    condensedCrumbs.remove();
+  condensedCrumbs.after(breadcrumbs);
+  condensedCrumbs.remove();
 }
 
 /**
@@ -507,40 +507,40 @@ function expandBreadCrumbs(e) {
  * @param {event} e click event
  */
 function condenseBreadCrumbs(e) {
-    // not always called from an event
-    if (e) {
-        e.preventDefault();
-    }
+  // not always called from an event
+  if (e) {
+    e.preventDefault();
+  }
 
-    breadcrumbs.after(condensedCrumbs);
-    breadcrumbs.remove();
+  breadcrumbs.after(condensedCrumbs);
+  breadcrumbs.remove();
 }
 
 /**
  * Sets breadcrumbs back to their original settings for desktop view
  */
 function resetBreadCrumbs() {
-    if (originalBreadcrumbs) {
+  if (originalBreadcrumbs) {
 
-        condensedCrumbs.after(originalBreadcrumbs);
-        condensedCrumbs.remove();
-    }
+    condensedCrumbs.after(originalBreadcrumbs);
+    condensedCrumbs.remove();
+  }
 }
 
 /**
  * Check if user requests reduced motion and pause all videos.
  */
 function reducedMotionCheck() {
-    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const videoList = document.getElementsByTagName("video");
-    if (motionQuery.matches) {
-        // If the AOS library is loaded we probably have an animation.
-        if (typeof AOS !== "undefined") {
-            // This will trigger all animations to be disabled and everything should show up.
-            AOS.init({disable: true});
-        }
-        for (let i = 0; i < videoList.length; i++) {
-            videoList[i].pause();
-        }
+  const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  const videoList = document.getElementsByTagName("video");
+  if (motionQuery.matches) {
+    // If the AOS library is loaded we probably have an animation.
+    if (typeof AOS !== "undefined") {
+      // This will trigger all animations to be disabled and everything should show up.
+      AOS.init({disable: true});
     }
+    for (let i = 0; i < videoList.length; i++) {
+      videoList[i].pause();
+    }
+  }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,29 +6,32 @@ var sourcemaps = require('gulp-sourcemaps');
 
 
 function buildStyles() {
-    return gulp.src('./src/madrone.scss')
-        .pipe(sourcemaps.init())
-        .pipe(sass().on('error', sass.logError))
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest('./dist'));
+  return gulp.src('./src/madrone.scss')
+    .pipe(sourcemaps.init())
+    .pipe(sass().on('error', sass.logError))
+    .pipe(sourcemaps.write('./'))
+    .pipe(gulp.dest('./dist'));
 }
 
 function copyBSScripts() {
-    return gulp.src([
-        './node_modules/bootstrap/dist/js/bootstrap.bundle.js',
-        './node_modules/bootstrap/dist/js/bootstrap.bundle.js.map'
-    ])
-        .pipe(gulp.dest('dist/'));
+  return gulp.src([
+    './node_modules/bootstrap/dist/js/bootstrap.bundle.js',
+    './node_modules/bootstrap/dist/js/bootstrap.bundle.js.map'
+  ])
+    .pipe(gulp.dest('dist/'));
 }
 
 function buildScripts() {
-    return gulp.src('./src/madrone.js')
-        .pipe(gulp.dest('dist/'))
+  return gulp.src([
+    './src/madrone.js',
+    './src/madrone-editoria11y.js'
+  ])
+    .pipe(gulp.dest('dist/'))
 }
 
 function watchFiles() {
-    gulp.watch('./src/**/*.scss', gulp.series(buildStyles));
-    gulp.watch('./src/**/*.js', gulp.series(buildScripts));
+  gulp.watch('./src/**/*.scss', gulp.series(buildStyles));
+  gulp.watch('./src/**/*.js', gulp.series(buildScripts));
 }
 
 exports.buildStyles = buildStyles;

--- a/madrone.libraries.yml
+++ b/madrone.libraries.yml
@@ -4,6 +4,7 @@ global-styling:
       dist/madrone.css: { }
   js:
     dist/madrone.js: { }
+    dist/madrone-editoria11y.js: { }
   dependencies:
     - core/drupal
     - core/jquery

--- a/src/madrone-editoria11y.js
+++ b/src/madrone-editoria11y.js
@@ -1,0 +1,106 @@
+document.addEventListener('ed11yRunCustomTests', () => {
+
+  // 1. Write your custom test.
+  // This can be anything you want.
+  //
+  // This example uses Ed11y.findElements(),
+  // which respects checkRoots and ignoreElements,
+  // to find links with a particular string in their URL.
+  Ed11y.findElements('safeLinks', 'a[href*="safelinks.protection.outlook.com/?"]');
+
+  // Hard Dev links should be avoided.
+  Ed11y.findElements('devLinks', 'a[href*="dev.oregonstate.edu"]');
+
+  // 2. Create a message for your tooltip.
+  // You'll need a title and some contents,
+  // as a value for the key you create for your test.
+  //
+  // Be sure to use the same key as the test name below.
+  Ed11y.M.outlookSafeLink = {
+    title: 'URL is Safe Link encoded',
+    tip: (href) =>
+      `<p>The URL for this link has been copied from an email.
+              It includes the original recipient's email address,
+              and will bounce all clicks through the Outlook Safelinks server.</p>
+          <p>The specified URL is:<br>
+          <em style='word-break: break-all;font-size:90%;line-height: 1.2;display: block;'>
+             ${Ed11y.sanitizeForHTML(href)}
+          </em></p>
+          ${decodeSafelink(href)}
+          `,
+  };
+
+  Ed11y.M.devLink = {
+    title: 'URL is hard linking to Development site',
+    tip: (href) => `
+    <p>The URL for this link is using a full URL to the Development Site, Relative links should be used.</p>
+    <p>The specified URL is:<br>
+    <em>${Ed11y.sanitizeForHTML(href)}</em>
+    </p>
+    ${decodeDevLink(href)}
+    `,
+  };
+
+  // 3. Push each item you want flagged to Ed11y.results.
+  //
+  // You must provide:
+  //   el: The element
+  //   test: A key for your test
+  //   content: The tip you created above.
+  //   position: "beforebegin" for images and links,
+  //             "afterbegin" for paragraphs.
+  //   dismissalKey: false for errors,
+  //             a unique string for manual checks.
+  Ed11y.elements.safeLinks?.forEach((el) => {
+    Ed11y.results.push({
+      element: el,
+      test: 'outlookSafeLink',
+      content: Ed11y.M.outlookSafeLink.tip(el.getAttribute('href')),
+      position: 'beforebegin',
+      dismissalKey: false,
+    })
+  })
+
+  Ed11y.elements.devLinks?.forEach((el) => {
+    Ed11y.results.push({
+      element: el,
+      test: 'devLink',
+      content: Ed11y.M.devLink.tip(el.getAttribute('href')),
+      position: 'beforebegin',
+      dismissalKey: false,
+    })
+  })
+
+  // 4. When you are done with all your custom tests,
+  // dispatch an "ed11yResume" event:
+  let allDone = new CustomEvent('ed11yResume');
+  document.dispatchEvent(allDone);
+});
+
+/**
+ * Decodes a Safelink URL and returns the actual URL.
+ *
+ * @param {string} url - The Safelink URL to decode.
+ * @returns {string} - The actual URL, formatted as an HTML paragraph.
+ *                    If the Safelink URL does not contain a 'url' parameter, an empty string is returned.
+ */
+function decodeSafelink(url) {
+  const params = new URL(url).searchParams;
+  let decoded = params.get('url');
+  if (!!decoded) {
+    decoded = Ed11y.sanitizeForHTML(decoded);
+    return `<p>The actual URL may be:<br><em style='word-wrap: break-word;'>${decoded}</em></p>`
+  }
+  return '';
+}
+
+/**
+ * Decodes a developer link URL and returns the relative URL as a string.
+ *
+ * @param {string} url - The developer link URL to decode.
+ * @return {string} - The decoded relative URL.
+ */
+function decodeDevLink(url) {
+  const pathname = new URL(url).pathname;
+  return `<p>The relative URL may be:<br><em style='word-wrap: break-word;'>${Ed11y.sanitizeForHTML(pathname)}</em>`
+}

--- a/src/madrone-editoria11y.js
+++ b/src/madrone-editoria11y.js
@@ -22,38 +22,41 @@ document.addEventListener('ed11yRunCustomTests', () => {
   // Be sure to use the same key as the test name below.
   Ed11y.M.outlookSafeLink = {
     title: 'URL is Safe Link encoded',
-    tip: (href) =>
-      `<p>The URL for this link has been copied from an email.
-              It includes the original recipient's email address,
-              and will bounce all clicks through the Outlook Safelinks server.</p>
-          <p>The specified URL is:<br>
-          <em style='word-break: break-all;font-size:90%;line-height: 1.2;display: block;'>
-             ${Ed11y.sanitizeForHTML(href)}
-          </em></p>
-          ${decodeSafelink(href)}
-          `,
+    tip: (href) => `
+        <p>The URL for this link has been copied from an email. It includes the original recipient's email address,
+        and will bounce all clicks through the Outlook Safelinks server.
+         </p>
+        <p>The specified URL is:<br>
+            <em style='word-break: break-all;font-size:90%;line-height: 1.2;display: block;'>
+                ${Ed11y.sanitizeForHTML(href)}
+            </em>
+        </p>
+        ${decodeSafelink(href)}
+    `,
   }
 
   Ed11y.M.devLink = {
     title: 'URL is hard linking to Development site',
-    tip: (href) =>
-      `<p>The URL for this link is using a full URL to the Development Site, Relative links should be used.</p>
-       <p>The specified URL is:<br>
-        <em>${Ed11y.sanitizeForHTML(href)}</em>
-       </p>
-    ${getPathFromUrl(href)}`,
+    tip: (href) => `
+        <p>The URL for this link is using a full URL to the Development Site, Relative links should be used.</p>
+        <p>The specified URL is:<br>
+            <em>${Ed11y.sanitizeForHTML(href)}</em>
+        </p>
+        ${getPathFromUrl(href)}
+    `,
   }
 
   Ed11y.M.sameSiteFullLink = {
     title: 'Manual Check: did you mean to use a full link?',
-    tip: (href) =>
-      `<p>Using a Fully Qualified Domain Name when linking internally is discouraged.</p>
-       <p>The specified URL is:<br/>
-       <em>${Ed11y.sanitizeForHTML(href)}</em>
-       </p>
-       <p>Generally when linking to pages/files within the same site it is best to use the tools provided in the
+    tip: (href) => `
+        <p>Using a Fully Qualified Domain Name when linking internally is discouraged.</p>
+        <p>The specified URL is:<br/>
+            <em>${Ed11y.sanitizeForHTML(href)}</em>
+        </p>
+        <p>Generally when linking to pages/files within the same site it is best to use the tools provided in the
            content editor to generate links correctly.</p>
-        ${getPathFromUrl(href)}`,
+        ${getPathFromUrl(href)}
+    `,
   }
 
   // 3. Push each item you want flagged to Ed11y.results.

--- a/src/madrone.js
+++ b/src/madrone.js
@@ -9,133 +9,133 @@ let originalBreadcrumbs;
 let breadcrumbs;
 let condensedCrumbs;
 window.addEventListener('load', () => {
-    reducedMotionCheck();
-    const superfishMenus = [...document.querySelectorAll('ul.sf-menu')];
-    superfishMenus.map(menu => {
-        let menuId = menu.getAttribute('id');
-        let menuToggles = document.querySelectorAll(`a#${menuId}-toggle`);
-        [...menuToggles].map(menuToggle => {
-            menuToggle.addEventListener('click', event => {
-                menuClickedText(menuToggle);
-            })
-        })
-    });
+  reducedMotionCheck();
+  const superfishMenus = [...document.querySelectorAll('ul.sf-menu')];
+  superfishMenus.map(menu => {
+    let menuId = menu.getAttribute('id');
+    let menuToggles = document.querySelectorAll(`a#${menuId}-toggle`);
+    [...menuToggles].map(menuToggle => {
+      menuToggle.addEventListener('click', event => {
+        menuClickedText(menuToggle);
+      })
+    })
+  });
 
-    // Check on page load if we need to be a mobile menu.
-    if (window.innerWidth <= 768) {
-        groupMobileMenu();
-        const groupMenu = document.querySelector('#group-content-menu');
-        if (groupMenu) {
-            groupMenu.classList.add('d-none');
-        }
-
-        mobileBreadcrumbs();
+  // Check on page load if we need to be a mobile menu.
+  if (window.innerWidth <= 768) {
+    groupMobileMenu();
+    const groupMenu = document.querySelector('#group-content-menu');
+    if (groupMenu) {
+      groupMenu.classList.add('d-none');
     }
 
-    // handle group menu horizontal spacing
-    const groupMenus = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li ul')];
-    groupMenus.forEach(menu => {
-        resizeMenu(menu);
-        if (!menu.classList.contains('menu--level-2')) {
-            // move the child element 100% of its width.
-            menu.style.left = '100%';
-        }
+    mobileBreadcrumbs();
+  }
+
+  // handle group menu horizontal spacing
+  const groupMenus = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li ul')];
+  groupMenus.forEach(menu => {
+    resizeMenu(menu);
+    if (!menu.classList.contains('menu--level-2')) {
+      // move the child element 100% of its width.
+      menu.style.left = '100%';
+    }
+  });
+
+  // this must come after groupMobileMenu() since .menu--level-1 changes there
+  const liList = [...document.querySelectorAll('.block-group-content-menu .menu--level-1 li')];
+  liList.forEach(li => {
+    // if li has child ul element
+    if ([...(li.children)].some(e => e.tagName === 'UL')) {
+      // add class chevron icon
+      li.classList.add('group-sub-menu');
+    }
+  });
+
+  // Add event listeners only for desktop.
+  const desktopMenuLiList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li')];
+  desktopMenuLiList.forEach(desktopLi => {
+    desktopLi.addEventListener('mouseenter', menuItemHoverEvent);
+    desktopLi.addEventListener('focusin', menuItemFocusinEvent);
+    desktopLi.addEventListener('mouseleave', menuItemMouseLeaveEvent);
+    desktopLi.addEventListener('focusout', menuItemMouseLeaveEvent);
+  });
+
+  // Add an overflow hidden class to the parent element if the block is inside a column class and has animations.
+  const animatedBlocks = [...document.querySelectorAll(".block.aos-init")];
+  animatedBlocks.map(block => {
+    let blockParent = block.parentElement;
+    for (let i = 0; i < blockParent.classList.length; i++) {
+      if (/col-.*/.test(blockParent.classList[i])) {
+        blockParent.classList.add('overflow-hidden');
+        break;
+      }
+    }
+  });
+
+  // ToCJS Width setter.
+  const tocJsBlocks = document.querySelectorAll(".toc-js");
+  if (tocJsBlocks.length > 0) {
+    let tocJsBlock = tocJsBlocks[0];
+    let tocJsParentBlock = tocJsBlock.closest('.block[class*="toc-js"]');
+    const tocJsParentBlockStyle = window.getComputedStyle(tocJsParentBlock);
+
+    resizeTocJsBlock(tocJsBlock);
+
+    let prevClassState = tocJsBlock.classList.contains('is-sticked');
+    // We only care about background, border, and padding.
+    let classesToCopy = [...tocJsParentBlockStyle].filter((key) => {
+      if (/^border.*/.test(key) || /^background.*/.test(key) || /^padding.*/.test(key)) {
+        return key;
+      }
     });
-
-    // this must come after groupMobileMenu() since .menu--level-1 changes there
-    const liList = [...document.querySelectorAll('.block-group-content-menu .menu--level-1 li')];
-    liList.forEach(li => {
-        // if li has child ul element
-        if ([...(li.children)].some(e => e.tagName === 'UL')) {
-            // add class chevron icon
-            li.classList.add('group-sub-menu');
-        }
-    });
-
-    // Add event listeners only for desktop.
-    const desktopMenuLiList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu.menu--level-1 li')];
-    desktopMenuLiList.forEach(desktopLi => {
-        desktopLi.addEventListener('mouseenter', menuItemHoverEvent);
-        desktopLi.addEventListener('focusin', menuItemFocusinEvent);
-        desktopLi.addEventListener('mouseleave', menuItemMouseLeaveEvent);
-        desktopLi.addEventListener('focusout', menuItemMouseLeaveEvent);
-    });
-
-    // Add an overflow hidden class to the parent element if the block is inside a column class and has animations.
-    const animatedBlocks = [...document.querySelectorAll(".block.aos-init")];
-    animatedBlocks.map(block => {
-        let blockParent = block.parentElement;
-        for (let i = 0; i < blockParent.classList.length; i++) {
-            if (/col-.*/.test(blockParent.classList[i])) {
-                blockParent.classList.add('overflow-hidden');
-                break;
-            }
-        }
-    });
-
-    // ToCJS Width setter.
-    const tocJsBlocks = document.querySelectorAll(".toc-js");
-    if (tocJsBlocks.length > 0) {
-        let tocJsBlock = tocJsBlocks[0];
-        let tocJsParentBlock = tocJsBlock.closest('.block[class*="toc-js"]');
-        const tocJsParentBlockStyle = window.getComputedStyle(tocJsParentBlock);
-
-        resizeTocJsBlock(tocJsBlock);
-
-        let prevClassState = tocJsBlock.classList.contains('is-sticked');
-        // We only care about background, border, and padding.
-        let classesToCopy = [...tocJsParentBlockStyle].filter((key) => {
-            if (/^border.*/.test(key) || /^background.*/.test(key) || /^padding.*/.test(key)) {
-                return key;
-            }
-        });
-        // We loaded the page not at the top, so we need to copy styles down.
-        if (prevClassState) {
+    // We loaded the page not at the top, so we need to copy styles down.
+    if (prevClassState) {
+      classesToCopy.forEach(cssClass => {
+        tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
+      });
+      // overwrite background color and border options when loading the page midway.
+      tocJsParentBlock.style.setProperty('background-color', 'transparent', 'important');
+      tocJsParentBlock.style.setProperty('border', '0', 'important');
+    }
+    // Create a mutation observer to watch for changes, specifically when the class 'is-sticked' is added/removed.
+    let tocJsObserver = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        if (mutation.attributeName === 'class') {
+          let currentClassState = mutation.target.classList.contains('is-sticked');
+          if (prevClassState !== currentClassState) {
+            prevClassState = currentClassState;
+          }
+          if (prevClassState) {
             classesToCopy.forEach(cssClass => {
-                tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
+              tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
             });
-            // overwrite background color and border options when loading the page midway.
+            // Set the margin left and to stop the block from jumping and set the background to transparent on the
+            // parent block to "hide" it when scrolled.
+            tocJsParentBlock.style.setProperty('margin-left', `-${tocJsParentBlockStyle.paddingLeft}`, 'important')
             tocJsParentBlock.style.setProperty('background-color', 'transparent', 'important');
             tocJsParentBlock.style.setProperty('border', '0', 'important');
-        }
-        // Create a mutation observer to watch for changes, specifically when the class 'is-sticked' is added/removed.
-        let tocJsObserver = new MutationObserver(mutations => {
-            mutations.forEach(mutation => {
-                if (mutation.attributeName === 'class') {
-                    let currentClassState = mutation.target.classList.contains('is-sticked');
-                    if (prevClassState !== currentClassState) {
-                        prevClassState = currentClassState;
-                    }
-                    if (prevClassState) {
-                        classesToCopy.forEach(cssClass => {
-                            tocJsBlock.style.setProperty(cssClass, tocJsParentBlockStyle.getPropertyValue(cssClass), tocJsParentBlockStyle.getPropertyPriority(cssClass));
-                        });
-                        // Set the margin left and to stop the block from jumping and set the background to transparent on the
-                        // parent block to "hide" it when scrolled.
-                        tocJsParentBlock.style.setProperty('margin-left', `-${tocJsParentBlockStyle.paddingLeft}`, 'important')
-                        tocJsParentBlock.style.setProperty('background-color', 'transparent', 'important');
-                        tocJsParentBlock.style.setProperty('border', '0', 'important');
-                    } else {
-                        classesToCopy.forEach(cssClass => {
-                            tocJsBlock.style.removeProperty(cssClass);
-                        });
-                        // Clear all classes we set.
-                        tocJsParentBlock.style.removeProperty('background-color');
-                        tocJsParentBlock.style.removeProperty('border');
-                        tocJsParentBlock.style.removeProperty('margin-left');
-                    }
-                }
+          } else {
+            classesToCopy.forEach(cssClass => {
+              tocJsBlock.style.removeProperty(cssClass);
             });
-        });
-        tocJsObserver.observe(tocJsBlock, {attributes: true, childList: false, characterData: false});
-    }
-    /* Simple Popup Blocks Module.
-     * Set Inline CSS Variables for margin-left.
-     */
-    document.querySelectorAll('.simple-popup-blocks-global .spb-popup-main-wrapper').forEach(osuSpb => {
-        osuSpb.style.setProperty('--spb-width', osuSpb.style.getPropertyValue('width'));
-        osuSpb.style.setProperty('--spb-margin-left', osuSpb.style.getPropertyValue('margin-left'));
-    })
+            // Clear all classes we set.
+            tocJsParentBlock.style.removeProperty('background-color');
+            tocJsParentBlock.style.removeProperty('border');
+            tocJsParentBlock.style.removeProperty('margin-left');
+          }
+        }
+      });
+    });
+    tocJsObserver.observe(tocJsBlock, {attributes: true, childList: false, characterData: false});
+  }
+  /* Simple Popup Blocks Module.
+   * Set Inline CSS Variables for margin-left.
+   */
+  document.querySelectorAll('.simple-popup-blocks-global .spb-popup-main-wrapper').forEach(osuSpb => {
+    osuSpb.style.setProperty('--spb-width', osuSpb.style.getPropertyValue('width'));
+    osuSpb.style.setProperty('--spb-margin-left', osuSpb.style.getPropertyValue('margin-left'));
+  })
 });
 
 /**
@@ -143,33 +143,33 @@ window.addEventListener('load', () => {
  * @param sfToggle
  */
 function menuClickedText(sfToggle) {
-    if (sfToggle.classList.contains('sf-expanded')) {
-        let menuToggleText = sfToggle.innerHTML;
-        sfToggle.innerHTML = `<span class="madrone-mobile-menu-close">Close&nbsp;</span>${menuToggleText}`
-    } else {
-        sfToggle.querySelector('span.madrone-mobile-menu-close').remove()
-    }
+  if (sfToggle.classList.contains('sf-expanded')) {
+    let menuToggleText = sfToggle.innerHTML;
+    sfToggle.innerHTML = `<span class="madrone-mobile-menu-close">Close&nbsp;</span>${menuToggleText}`
+  } else {
+    sfToggle.querySelector('span.madrone-mobile-menu-close').remove()
+  }
 }
 
 /**
  * Create the mobile menu cloning the exiting menu.
  */
 function groupMobileMenu() {
-    // Create menu top level bucket
-    const menus = document.querySelectorAll('ul#group-content-menu');
-    menus.forEach((menu) => {
-        createMenuBucket(menu);
-    });
+  // Create menu top level bucket
+  const menus = document.querySelectorAll('ul#group-content-menu');
+  menus.forEach((menu) => {
+    createMenuBucket(menu);
+  });
 
-    const liList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu-accordion .menu--level-1 li')];
-    liList.forEach(li => {
-        // if li has child ul element
-        if ([...(li.children)].some(e => e.tagName === 'UL')) {
-            cloneLi(li);
+  const liList = [...document.querySelectorAll('.block-group-content-menu ul#group-content-menu-accordion .menu--level-1 li')];
+  liList.forEach(li => {
+    // if li has child ul element
+    if ([...(li.children)].some(e => e.tagName === 'UL')) {
+      cloneLi(li);
 
-            li.children[0].addEventListener('click', menuItemClickEvent);
-        }
-    });
+      li.children[0].addEventListener('click', menuItemClickEvent);
+    }
+  });
 }
 
 /**
@@ -177,30 +177,30 @@ function groupMobileMenu() {
  * @param menu
  */
 function createMenuBucket(menu) {
-    // Do a deep clone cleaning all extra styles.
-    const deepMenuClone = cleanDeepClone(menu);
-    // Create new top level ul.
-    const topUl = document.createElement('ul');
-    topUl.id = 'group-content-menu-accordion';
-    topUl.classList = menu.classList;
-    topUl.classList.remove('menu--level-1');
-    topUl.classList.add('menu--level-0', 'group-mobile-menu');
+  // Do a deep clone cleaning all extra styles.
+  const deepMenuClone = cleanDeepClone(menu);
+  // Create new top level ul.
+  const topUl = document.createElement('ul');
+  topUl.id = 'group-content-menu-accordion';
+  topUl.classList = menu.classList;
+  topUl.classList.remove('menu--level-1');
+  topUl.classList.add('menu--level-0', 'group-mobile-menu');
 
-    const topLi = document.createElement('li');
-    topLi.classList = menu.children[0].classList;
+  const topLi = document.createElement('li');
+  topLi.classList = menu.children[0].classList;
 
-    const topA = document.createElement('a');
-    topA.classList = menu.children[0].children[0].classList;
-    topA.classList.add('group-mobile-main-a');
-    topA.innerHTML = 'Menu';
+  const topA = document.createElement('a');
+  topA.classList = menu.children[0].children[0].classList;
+  topA.classList.add('group-mobile-main-a');
+  topA.innerHTML = 'Menu';
 
-    topLi.appendChild(topA);
-    topUl.appendChild(topLi);
-    menu.parentNode.insertBefore(topUl, menu);
-    // Append the cloned menu so we can target it with hide/show.
-    topLi.appendChild(deepMenuClone);
+  topLi.appendChild(topA);
+  topUl.appendChild(topLi);
+  menu.parentNode.insertBefore(topUl, menu);
+  // Append the cloned menu so we can target it with hide/show.
+  topLi.appendChild(deepMenuClone);
 
-    topA.addEventListener('click', menuItemClickEvent);
+  topA.addEventListener('click', menuItemClickEvent);
 }
 
 /**
@@ -209,13 +209,13 @@ function createMenuBucket(menu) {
  * @returns Node
  */
 function cleanDeepClone(menu) {
-    const deepClone = menu.cloneNode(true);
-    deepClone.removeAttribute("id");
-    const deepCloneSubMenus = deepClone.querySelectorAll('ul');
-    deepCloneSubMenus.forEach(deepCloneSubMenu => {
-        deepCloneSubMenu.style.left = null;
-    })
-    return deepClone;
+  const deepClone = menu.cloneNode(true);
+  deepClone.removeAttribute("id");
+  const deepCloneSubMenus = deepClone.querySelectorAll('ul');
+  deepCloneSubMenus.forEach(deepCloneSubMenu => {
+    deepCloneSubMenu.style.left = null;
+  })
+  return deepClone;
 }
 
 /**
@@ -223,20 +223,20 @@ function cleanDeepClone(menu) {
  * @param event
  */
 function menuItemClickEvent(event) {
-    // prevent clicks from navigating to the html <a> element.
-    event.preventDefault();
+  // prevent clicks from navigating to the html <a> element.
+  event.preventDefault();
 
-    // add styling and change text when clicked
-    if (this.parentNode.classList.contains('group-menu-clicked')) {
-        this.parentNode.classList.remove('group-menu-clicked');
+  // add styling and change text when clicked
+  if (this.parentNode.classList.contains('group-menu-clicked')) {
+    this.parentNode.classList.remove('group-menu-clicked');
 
-        this.textContent = this.textContent.replace('Close ', '');
-    } else {
-        this.parentNode.classList.add('group-menu-clicked');
+    this.textContent = this.textContent.replace('Close ', '');
+  } else {
+    this.parentNode.classList.add('group-menu-clicked');
 
-        const menuToggleText = this.textContent;
-        this.textContent = `Close ${menuToggleText}`;
-    }
+    const menuToggleText = this.textContent;
+    this.textContent = `Close ${menuToggleText}`;
+  }
 }
 
 /**
@@ -244,38 +244,38 @@ function menuItemClickEvent(event) {
  * @param event
  */
 function menuItemHoverEvent(event) {
-    if (this.classList.contains('group-menu-hover') && this.mouseLeaveTimeout) {
-        // prevent menu from hiding if the mouse leaves only for a moment
-        clearTimeout(this.mouseLeaveTimeout);
-    } else {
-        // If the menu might open off-screen move it, so it won't overflow.
-        // Get the Window Width.
-        const windowWidth = window.innerWidth;
-        // The full size of the menu item, this is the li.
-        const menuWidth = this.offsetWidth;
-        // Find the next UL in the menu tree down.
-        const menuChild = this.querySelector('ul');
-        if (menuChild) {
-            // Get the Full width of the new child menu item.
-            const menuChildWidth = menuChild.offsetWidth;
-            // Calculate how far right the new menu item might go.
-            const menuRight = menuChildWidth + menuChild.getBoundingClientRect().left;
-            // Ensure that the menu item will not go beyond the screen size.
-            if (menuRight > (windowWidth + window.scrollX)) {
-                if (menuChild.classList.contains('menu--level-2')) {
-                    // Let's set the first nested menu to line up with the parents right side.
-                    const menuParentRight = menuChild.closest('li').getBoundingClientRect().right;
-                    menuChild.style.left = 'auto';
-                    menuChild.style.right = `${windowWidth-menuParentRight}px`;
+  if (this.classList.contains('group-menu-hover') && this.mouseLeaveTimeout) {
+    // prevent menu from hiding if the mouse leaves only for a moment
+    clearTimeout(this.mouseLeaveTimeout);
+  } else {
+    // If the menu might open off-screen move it, so it won't overflow.
+    // Get the Window Width.
+    const windowWidth = window.innerWidth;
+    // The full size of the menu item, this is the li.
+    const menuWidth = this.offsetWidth;
+    // Find the next UL in the menu tree down.
+    const menuChild = this.querySelector('ul');
+    if (menuChild) {
+      // Get the Full width of the new child menu item.
+      const menuChildWidth = menuChild.offsetWidth;
+      // Calculate how far right the new menu item might go.
+      const menuRight = menuChildWidth + menuChild.getBoundingClientRect().left;
+      // Ensure that the menu item will not go beyond the screen size.
+      if (menuRight > (windowWidth + window.scrollX)) {
+        if (menuChild.classList.contains('menu--level-2')) {
+          // Let's set the first nested menu to line up with the parents right side.
+          const menuParentRight = menuChild.closest('li').getBoundingClientRect().right;
+          menuChild.style.left = 'auto';
+          menuChild.style.right = `${windowWidth - menuParentRight}px`;
 
-                } else {
-                    menuChild.style.left = `-${menuChildWidth}px`;
-                    menuChild.style.right = 'auto';
-                }
-            }
+        } else {
+          menuChild.style.left = `-${menuChildWidth}px`;
+          menuChild.style.right = 'auto';
         }
-        this.classList.add('group-menu-hover');
+      }
     }
+    this.classList.add('group-menu-hover');
+  }
 }
 
 /**
@@ -283,9 +283,9 @@ function menuItemHoverEvent(event) {
  * @param event
  */
 function menuItemFocusinEvent(event) {
-    if (!this.classList.contains('group-menu-hover')) {
-        this.classList.add('group-menu-hover');
-    }
+  if (!this.classList.contains('group-menu-hover')) {
+    this.classList.add('group-menu-hover');
+  }
 }
 
 /**
@@ -293,18 +293,18 @@ function menuItemFocusinEvent(event) {
  * @param event
  */
 function menuItemMouseLeaveEvent(event) {
-    const groupMenu = document.querySelectorAll('.block-group-content-menu')[0];
-    if (this.classList.contains('group-menu-hover') && !event.currentTarget.contains(event.relatedTarget)) {
-        // remove hover immediately if next target is still in the menu
-        // otherwise wait a bit
-        if (groupMenu.contains(event.relatedTarget)) {
-            this.classList.remove('group-menu-hover');
-        } else {
-            this.mouseLeaveTimeout = setTimeout(() => {
-                this.classList.remove('group-menu-hover');
-            }, 800);
-        }
+  const groupMenu = document.querySelectorAll('.block-group-content-menu')[0];
+  if (this.classList.contains('group-menu-hover') && !event.currentTarget.contains(event.relatedTarget)) {
+    // remove hover immediately if next target is still in the menu
+    // otherwise wait a bit
+    if (groupMenu.contains(event.relatedTarget)) {
+      this.classList.remove('group-menu-hover');
+    } else {
+      this.mouseLeaveTimeout = setTimeout(() => {
+        this.classList.remove('group-menu-hover');
+      }, 800);
     }
+  }
 }
 
 /**
@@ -312,10 +312,10 @@ function menuItemMouseLeaveEvent(event) {
  * @param li
  */
 function cloneLi(li) {
-    const clonedA = li.children[0].cloneNode(true);
-    const clonedLi = document.createElement('li');
-    clonedLi.appendChild(clonedA);
-    li.children[1].prepend(clonedLi);
+  const clonedA = li.children[0].cloneNode(true);
+  const clonedLi = document.createElement('li');
+  clonedLi.appendChild(clonedA);
+  li.children[1].prepend(clonedLi);
 }
 
 /**
@@ -323,49 +323,49 @@ function cloneLi(li) {
  * @returns {RegExpMatchArray}
  */
 function isMobile() {
-    return navigator.userAgent.match(/(android|bb\d+|meego)|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i);
+  return navigator.userAgent.match(/(android|bb\d+|meego)|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i);
 }
 
 // Add event listener to browser resize.
 window.addEventListener('resize', (event) => {
-    const tocJsBlocks = document.querySelectorAll(".toc-js");
-    if (tocJsBlocks.length > 0) {
-        const tocJsBlock = tocJsBlocks[0];
-        clearTimeout(tocJsTimeout);
-        tocJsTimeout = setTimeout(resizeTocJsBlock(tocJsBlock), DELAY);
-    }
-    if (window.innerWidth <= 768) {
-        // only add mobile menu if it doesn't already exist.
-        let groupMobileId = document.querySelector('#group-content-menu-accordion');
-        let groupMenuId = document.querySelector('#group-content-menu');
-        if (groupMobileId === null) {
-            groupMobileMenu();
-            if (groupMenuId) {
-                groupMenuId.classList.add('d-none');
-            }
-        } else {
-
-            groupMenuId.classList.add('d-none');
-            groupMobileId.classList.remove('d-none');
-            groupMobileId.classList.add('d-flex');
-        }
-
-        mobileBreadcrumbs();
+  const tocJsBlocks = document.querySelectorAll(".toc-js");
+  if (tocJsBlocks.length > 0) {
+    const tocJsBlock = tocJsBlocks[0];
+    clearTimeout(tocJsTimeout);
+    tocJsTimeout = setTimeout(resizeTocJsBlock(tocJsBlock), DELAY);
+  }
+  if (window.innerWidth <= 768) {
+    // only add mobile menu if it doesn't already exist.
+    let groupMobileId = document.querySelector('#group-content-menu-accordion');
+    let groupMenuId = document.querySelector('#group-content-menu');
+    if (groupMobileId === null) {
+      groupMobileMenu();
+      if (groupMenuId) {
+        groupMenuId.classList.add('d-none');
+      }
     } else {
-        // add back desktop menu if mobile menu was added.
-        let groupMobileId = document.querySelector('#group-content-menu-accordion');
-        let groupMenuId = document.querySelector('#group-content-menu');
-        if (groupMobileId !== null) {
-            groupMobileId.classList.remove('d-flex');
-            groupMobileId.classList.add('d-none');
-            groupMenuId.classList.remove('d-none');
-            groupMenuId.classList.add('d-flex');
-        }
 
-        if (condensedCrumbs) {
-            resetBreadCrumbs();
-        }
+      groupMenuId.classList.add('d-none');
+      groupMobileId.classList.remove('d-none');
+      groupMobileId.classList.add('d-flex');
     }
+
+    mobileBreadcrumbs();
+  } else {
+    // add back desktop menu if mobile menu was added.
+    let groupMobileId = document.querySelector('#group-content-menu-accordion');
+    let groupMenuId = document.querySelector('#group-content-menu');
+    if (groupMobileId !== null) {
+      groupMobileId.classList.remove('d-flex');
+      groupMobileId.classList.add('d-none');
+      groupMenuId.classList.remove('d-none');
+      groupMenuId.classList.add('d-flex');
+    }
+
+    if (condensedCrumbs) {
+      resetBreadCrumbs();
+    }
+  }
 });
 
 /**
@@ -373,21 +373,21 @@ window.addEventListener('resize', (event) => {
  * @param menu
  */
 function resizeMenu(menu) {
-    menu.style.width = "auto";
-    let menuUlMaxLength = 0;
-    menu.querySelectorAll('li').forEach(menuLi => {
-        menuLi.setAttribute('style', 'white-space:nowrap;');
-        let largestItem = Math.ceil(menuLi.clientWidth / fontSize);
-        if (largestItem < smallestEm) {
-            menuUlMaxLength = smallestEm;
-        } else if (largestItem > largestEm) {
-            menuUlMaxLength = largestEm;
-        } else {
-            menuUlMaxLength = largestItem + 1;
-        }
-        menuLi.setAttribute('style', '');
-    });
-    menu.style.width = `${menuUlMaxLength}em`;
+  menu.style.width = "auto";
+  let menuUlMaxLength = 0;
+  menu.querySelectorAll('li').forEach(menuLi => {
+    menuLi.setAttribute('style', 'white-space:nowrap;');
+    let largestItem = Math.ceil(menuLi.clientWidth / fontSize);
+    if (largestItem < smallestEm) {
+      menuUlMaxLength = smallestEm;
+    } else if (largestItem > largestEm) {
+      menuUlMaxLength = largestEm;
+    } else {
+      menuUlMaxLength = largestItem + 1;
+    }
+    menuLi.setAttribute('style', '');
+  });
+  menu.style.width = `${menuUlMaxLength}em`;
 }
 
 /**
@@ -397,46 +397,46 @@ function resizeMenu(menu) {
  * @return boolean
  */
 function resizeTocJsBlock(block) {
-    let closestParentBlock = block.closest('.block[class*="toc-js"]');
-    const parentBlockStyle = window.getComputedStyle(closestParentBlock);
-    const finalPadding = parseFloat(parentBlockStyle.paddingLeft) + parseFloat(parentBlockStyle.paddingRight);
-    const finalMargin = parseFloat(parentBlockStyle.marginLeft) + parseFloat(parentBlockStyle.marginRight);
-    const finalWidth = closestParentBlock.clientWidth - finalMargin - finalPadding;
-    block.style.width = `${finalWidth}px`;
-    return true;
+  let closestParentBlock = block.closest('.block[class*="toc-js"]');
+  const parentBlockStyle = window.getComputedStyle(closestParentBlock);
+  const finalPadding = parseFloat(parentBlockStyle.paddingLeft) + parseFloat(parentBlockStyle.paddingRight);
+  const finalMargin = parseFloat(parentBlockStyle.marginLeft) + parseFloat(parentBlockStyle.marginRight);
+  const finalWidth = closestParentBlock.clientWidth - finalMargin - finalPadding;
+  block.style.width = `${finalWidth}px`;
+  return true;
 }
 
 /**
  * Condense breadcrumbs list when >= 3 pages deep
  */
 function mobileBreadcrumbs() {
-    if (!breadcrumbs) {
-        breadcrumbs = document.querySelector('nav ol.breadcrumb');
-        if (breadcrumbs !== null) {
-            originalBreadcrumbs = breadcrumbs.cloneNode(true);
-            truncateCrumbs();
+  if (!breadcrumbs) {
+    breadcrumbs = document.querySelector('nav ol.breadcrumb');
+    if (breadcrumbs !== null) {
+      originalBreadcrumbs = breadcrumbs.cloneNode(true);
+      truncateCrumbs();
+    }
+  }
+  if (!originalBreadcrumbs && breadcrumbs !== null) {
+    originalBreadcrumbs = breadcrumbs.cloneNode(true);
+  }
+  if (breadcrumbs) {
+    const numCrumbs = breadcrumbs.children.length;
+    if (numCrumbs >= 3) {
+      if (!condensedCrumbs) {
+        createCondensedCrumbs(breadcrumbs);
+      } else {
+        // if originalBreadCrumbs has a parentNode then it is in the DOM, if not breadcrumbs is in DOM
+        if (originalBreadcrumbs.parentNode) {
+          originalBreadcrumbs.after(condensedCrumbs);
+          originalBreadcrumbs.remove();
+        } else {
+          breadcrumbs.after(condensedCrumbs);
         }
+      }
+      breadcrumbs.remove();
     }
-    if (!originalBreadcrumbs && breadcrumbs !== null) {
-        originalBreadcrumbs = breadcrumbs.cloneNode(true);
-    }
-    if (breadcrumbs) {
-        const numCrumbs = breadcrumbs.children.length;
-        if (numCrumbs >= 3) {
-            if (!condensedCrumbs) {
-                createCondensedCrumbs(breadcrumbs);
-            } else {
-                // if originalBreadCrumbs has a parentNode then it is in the DOM, if not breadcrumbs is in DOM
-                if (originalBreadcrumbs.parentNode) {
-                    originalBreadcrumbs.after(condensedCrumbs);
-                    originalBreadcrumbs.remove();
-                } else {
-                    breadcrumbs.after(condensedCrumbs);
-                }
-            }
-            breadcrumbs.remove();
-        }
-    }
+  }
 }
 
 /**
@@ -445,14 +445,14 @@ function mobileBreadcrumbs() {
  * @param {<ol> of breadcrumbs} breadcrumbs
  */
 function truncateCrumbs() {
-    const TEXT_LIMIT = 30;
-    [...breadcrumbs.children].forEach(crumb => {
-        if (crumb.children[0] && crumb.children[0].textContent.length > TEXT_LIMIT) {
-            crumb.children[0].textContent = `${crumb.children[0].textContent.substring(0, TEXT_LIMIT)}...`;
-        } else if (crumb.children.length === 0 && crumb.textContent.trim().length > TEXT_LIMIT) {
-            crumb.textContent = `${crumb.textContent.trim().substring(0, TEXT_LIMIT)}...`;
-        }
-    });
+  const TEXT_LIMIT = 30;
+  [...breadcrumbs.children].forEach(crumb => {
+    if (crumb.children[0] && crumb.children[0].textContent.length > TEXT_LIMIT) {
+      crumb.children[0].textContent = `${crumb.children[0].textContent.substring(0, TEXT_LIMIT)}...`;
+    } else if (crumb.children.length === 0 && crumb.textContent.trim().length > TEXT_LIMIT) {
+      crumb.textContent = `${crumb.textContent.trim().substring(0, TEXT_LIMIT)}...`;
+    }
+  });
 }
 
 /**
@@ -461,29 +461,29 @@ function truncateCrumbs() {
  * @param {<ol> of breadcrumbs} breadcrumbs
  */
 function createCondensedCrumbs(breadcrumbs) {
-    condensedCrumbs = document.createElement('ol');
-    condensedCrumbs.classList = ['breadcrumb breadcrumb-condensed'];
-    condensedCrumbs.appendChild(breadcrumbs.children[breadcrumbs.children.length - 2].cloneNode(true));
+  condensedCrumbs = document.createElement('ol');
+  condensedCrumbs.classList = ['breadcrumb breadcrumb-condensed'];
+  condensedCrumbs.appendChild(breadcrumbs.children[breadcrumbs.children.length - 2].cloneNode(true));
 
-    const expandCrumb = createCrumb('(expand)', breadcrumbs.children[0].classList, expandBreadCrumbs);
-    condensedCrumbs.children[0].before(expandCrumb);
-    const condenseCrumb = createCrumb('(condense)', [], condenseBreadCrumbs);
-    breadcrumbs.appendChild(condenseCrumb);
+  const expandCrumb = createCrumb('(expand)', breadcrumbs.children[0].classList, expandBreadCrumbs);
+  condensedCrumbs.children[0].before(expandCrumb);
+  const condenseCrumb = createCrumb('(condense)', [], condenseBreadCrumbs);
+  breadcrumbs.appendChild(condenseCrumb);
 
-    breadcrumbs.after(condensedCrumbs)
+  breadcrumbs.after(condensedCrumbs)
 }
 
 function createCrumb(textContent, classList, onclick) {
-    const crumb = document.createElement('li');
-    crumb.classList = classList;
+  const crumb = document.createElement('li');
+  crumb.classList = classList;
 
-    // create <a> tag with onclick event
-    crumb.appendChild(document.createElement('a'));
-    crumb.children[0].textContent = textContent;
-    crumb.children[0].href = '';
-    crumb.children[0].onclick = onclick;
+  // create <a> tag with onclick event
+  crumb.appendChild(document.createElement('a'));
+  crumb.children[0].textContent = textContent;
+  crumb.children[0].href = '';
+  crumb.children[0].onclick = onclick;
 
-    return crumb;
+  return crumb;
 }
 
 /**
@@ -492,13 +492,13 @@ function createCrumb(textContent, classList, onclick) {
  * @param {event} e click event
  */
 function expandBreadCrumbs(e) {
-    // not always called from an event
-    if (e) {
-        e.preventDefault();
-    }
+  // not always called from an event
+  if (e) {
+    e.preventDefault();
+  }
 
-    condensedCrumbs.after(breadcrumbs);
-    condensedCrumbs.remove();
+  condensedCrumbs.after(breadcrumbs);
+  condensedCrumbs.remove();
 }
 
 /**
@@ -507,40 +507,40 @@ function expandBreadCrumbs(e) {
  * @param {event} e click event
  */
 function condenseBreadCrumbs(e) {
-    // not always called from an event
-    if (e) {
-        e.preventDefault();
-    }
+  // not always called from an event
+  if (e) {
+    e.preventDefault();
+  }
 
-    breadcrumbs.after(condensedCrumbs);
-    breadcrumbs.remove();
+  breadcrumbs.after(condensedCrumbs);
+  breadcrumbs.remove();
 }
 
 /**
  * Sets breadcrumbs back to their original settings for desktop view
  */
 function resetBreadCrumbs() {
-    if (originalBreadcrumbs) {
+  if (originalBreadcrumbs) {
 
-        condensedCrumbs.after(originalBreadcrumbs);
-        condensedCrumbs.remove();
-    }
+    condensedCrumbs.after(originalBreadcrumbs);
+    condensedCrumbs.remove();
+  }
 }
 
 /**
  * Check if user requests reduced motion and pause all videos.
  */
 function reducedMotionCheck() {
-    const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const videoList = document.getElementsByTagName("video");
-    if (motionQuery.matches) {
-        // If the AOS library is loaded we probably have an animation.
-        if (typeof AOS !== "undefined") {
-            // This will trigger all animations to be disabled and everything should show up.
-            AOS.init({disable: true});
-        }
-        for (let i = 0; i < videoList.length; i++) {
-            videoList[i].pause();
-        }
+  const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  const videoList = document.getElementsByTagName("video");
+  if (motionQuery.matches) {
+    // If the AOS library is loaded we probably have an animation.
+    if (typeof AOS !== "undefined") {
+      // This will trigger all animations to be disabled and everything should show up.
+      AOS.init({disable: true});
     }
+    for (let i = 0; i < videoList.length; i++) {
+      videoList[i].pause();
+    }
+  }
 }


### PR DESCRIPTION
A new JavaScript file was created to add custom accessibility tests specifically for safely encoded links and hard links to development sites. The JavaScript file listens for the 'ed11yRunCustomTests' event and executes the tests, generating tooltips for every flagged element. The gulpfile.js has been altered to include the new file in the build process.