### PR TITLE
Add option for default 404 page in Madrone theme

### DIFF
--- a/config/install/madrone.settings.yml
+++ b/config/install/madrone.settings.yml
@@ -9,4 +9,5 @@ favicon:
   use_default: true
 madrone_companion_logo: osu
 madrone_monsido_site_id: ''
+madrone_use_default_404: 1
 mardone_metatag_osu: 1

--- a/config/schema/madrone.schema.yml
+++ b/config/schema/madrone.schema.yml
@@ -8,6 +8,9 @@ madrone.settings:
     madrone_monsido_site_id:
       type: string
       label: 'Monsido Site ID'
+    madrone_use_default_404:
+      type: integer
+      label: 'Use Theme provided 404 page'
     mardone_metatag_osu:
       type: integer
       label: 'Use OSU Metatag'

--- a/madrone.theme
+++ b/madrone.theme
@@ -123,8 +123,8 @@ function madrone_preprocess_block(&$variables) {
         $variables['companion_logo_link'] = $themeCompanionLogoData['link-path'];
         $variables['companion_logo_alt'] = $themeCompanionLogoData['alt-text'];
         $themeCrestPath = '/' . Drupal::theme()
-          ->getActiveTheme()
-          ->getPath() . '/assets/osu-logo-crest-only.svg';
+            ->getActiveTheme()
+            ->getPath() . '/assets/osu-logo-crest-only.svg';
         $variables['crest_logo'] = $themeCrestPath;
         if (array_key_exists('group_path', $variables['content']) &&
           array_key_exists('group_name', $variables['content'])) {
@@ -212,6 +212,21 @@ function madrone_preprocess_field(&$variables) {
         $variables['items'][$index]['content']['#options']['attributes']['class'][] = 'btn-primary';
       }
     }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function madrone_preprocess_page(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $status_codes = [
+    'system.403' => 403,
+    'system.404' => 404,
+  ];
+  if (isset($status_codes[$route_name])) {
+    $is_default_404 = theme_get_setting('madrone_use_default_404') ?? TRUE;
+    $variables['madrone_use_default_404'] = $is_default_404;
   }
 }
 
@@ -445,16 +460,16 @@ function get_companion_logo(string $companion_logo): array {
     'cascades' => [
       'logo-name' => 'cascades',
       'logo-path' => '/' . Drupal::theme()
-        ->getActiveTheme()
-        ->getPath() . '/assets/osucascades.svg',
+          ->getActiveTheme()
+          ->getPath() . '/assets/osucascades.svg',
       'link-path' => 'https://osucascades.edu/',
       'alt-text' => 'OSU-Cascades homepage',
     ],
     default => [
       'logo-name' => 'default',
       'logo-path' => '/' . Drupal::theme()
-        ->getActiveTheme()
-        ->getPath() . '/logo.svg',
+          ->getActiveTheme()
+          ->getPath() . '/logo.svg',
       'link-path' => 'https://oregonstate.edu/',
       'alt-text' => 'Oregon State University homepage',
     ]

--- a/madrone.theme
+++ b/madrone.theme
@@ -123,8 +123,8 @@ function madrone_preprocess_block(&$variables) {
         $variables['companion_logo_link'] = $themeCompanionLogoData['link-path'];
         $variables['companion_logo_alt'] = $themeCompanionLogoData['alt-text'];
         $themeCrestPath = '/' . Drupal::theme()
-            ->getActiveTheme()
-            ->getPath() . '/assets/osu-logo-crest-only.svg';
+          ->getActiveTheme()
+          ->getPath() . '/assets/osu-logo-crest-only.svg';
         $variables['crest_logo'] = $themeCrestPath;
         if (array_key_exists('group_path', $variables['content']) &&
           array_key_exists('group_name', $variables['content'])) {
@@ -460,16 +460,16 @@ function get_companion_logo(string $companion_logo): array {
     'cascades' => [
       'logo-name' => 'cascades',
       'logo-path' => '/' . Drupal::theme()
-          ->getActiveTheme()
-          ->getPath() . '/assets/osucascades.svg',
+        ->getActiveTheme()
+        ->getPath() . '/assets/osucascades.svg',
       'link-path' => 'https://osucascades.edu/',
       'alt-text' => 'OSU-Cascades homepage',
     ],
     default => [
       'logo-name' => 'default',
       'logo-path' => '/' . Drupal::theme()
-          ->getActiveTheme()
-          ->getPath() . '/logo.svg',
+        ->getActiveTheme()
+        ->getPath() . '/logo.svg',
       'link-path' => 'https://oregonstate.edu/',
       'alt-text' => 'Oregon State University homepage',
     ]

--- a/templates/layout/page--404.html.twig
+++ b/templates/layout/page--404.html.twig
@@ -15,6 +15,7 @@
  * - logged_in: A flag indicating if the user is registered and signed in.
  * - is_admin: A flag indicating if the user has permission to access
  *   administration pages.
+ * - madrone_use_default_404: A flag to either use this files contents or not.
  *
  * Site identity:
  * - front_page: The URL of the front page. Use this instead of base_path when
@@ -65,37 +66,43 @@
     <main class="d-flex flex-wrap flex-fill gx-3 gx-lg-0" role="main">
       <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
       <div{{ content_attributes.addClass(content_classes) }}>
-        <div class="container-fluid">
-          <div class="row g-0">
-            <div class="col-12 col-md-6" style="padding: 4rem;">
-              <h3>
-                404 <br/>
-                Page Not Found
-              </h3>
-              <p>
-                Hold up, eager beaver—it's building season. And you've run into Benny's dam.
-              </p>
+        {% if madrone_use_default_404 %}
+          <div class="container-fluid">
+            <div class="row g-0">
+              <div class="col-12 col-md-6" style="padding: 4rem;">
+                <h3>
+                  404 <br/>
+                  Page Not Found
+                </h3>
+                <p>
+                  Hold up, eager beaver—it's building season. And you've run into Benny's dam.
+                </p>
 
-              <h4>Options</h4>
+                <h4>Options</h4>
 
-              <ul>
-                <li>Use the <a href="https://search.oregonstate.edu/">site search</a> to find what you're looking for
-                </li>
-                <li>Looking for someone? Search the <a href="http://directory.oregonstate.edu/">OSU directory</a></li>
-                <li>Use your browser's <em>Back</em> button to return to the previous page</li>
-                <li>Go to the <a href="https://oregonstate.edu/">Oregon State homepage</a> to browse for the page you're
-                  looking for
-                </li>
-              </ul>
-            </div>
+                <ul>
+                  <li>Use the <a href="https://search.oregonstate.edu/">site search</a> to find what you're looking for
+                  </li>
+                  <li>Looking for someone? Search the <a href="http://directory.oregonstate.edu/">OSU directory</a></li>
+                  <li>Use your browser's <em>Back</em> button to return to the previous page</li>
+                  <li>Go to the <a href="https://oregonstate.edu/">Oregon State homepage</a> to browse for the page
+                    you're
+                    looking for
+                  </li>
+                </ul>
+              </div>
 
-            <div class="col-12 col-md-6 align-center" style="padding: 4rem;">
-              <img class="" src="{{ base_path }}{{ active_theme_path() }}/assets/404.svg"
-                   alt="{{ 'Mountain scene with 404 text'|t }}"/>
+              <div class="col-12 col-md-6 align-center" style="padding: 4rem;">
+                <img class="" src="{{ base_path }}{{ active_theme_path() }}/assets/404.svg"
+                     alt="{{ 'Mountain scene with 404 text'|t }}"/>
+              </div>
             </div>
           </div>
-        </div>
+        {% else %}
+          {{ page.content }}
+        {% endif %}
       </div>
+
       {% if page_sidebar_content %}
         <aside class="layout-sidebar ps-4 pe-4 ps-lg-2 pe-lg-2 ps-xxl-3 pe-xxl-3 col-lg-3 flex-fill"
                role="complementary">

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -28,6 +28,15 @@ function madrone_form_system_theme_settings_alter(&$form, FormStateInterface $fo
     '#default_value' => theme_get_setting('madrone_monsido_site_id'),
     '#description' => t("Site Id for monsido analytics"),
   ];
+
+  // Theme options for 404 page.
+  $form['madrone_settings']['madrone_utilities']['madrone_use_default_404'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Use Theme provided 404 page'),
+    '#default_value' => theme_get_setting('madrone_use_default_404'),
+    '#description' => t("Check to use the Theme provided 404, uncheck if you want to use your own node."),
+  ];
+
   // Site Logo Options.
   $form['madrone_settings']['madrone_utilities']['madrone_companion_logo'] = [
     '#type' => 'select',


### PR DESCRIPTION
An option to use a theme-provided 404 page has been included in the Madrone theme settings. This aims to give users more flexibility in page not found scenarios. A checkbox has been added to the theme settings form, and corresponding configurations and conditional rendering in the Twig file have been established to implement this feature.