### PR TITLE
Add display breakpoints for responsive design

### DIFF
--- a/madrone.breakpoints.yml
+++ b/madrone.breakpoints.yml
@@ -1,0 +1,42 @@
+madrone.mobile:
+  label: mobile
+  mediaQuery: '(min-width: 0px)'
+  weight: 0
+  multipliers:
+    - 1x
+    - 2x
+madrone.tablet:
+  label: tablet
+  mediaQuery: '(min-width: 576px)'
+  weight: 1
+  multipliers:
+    - 1x
+    - 2x
+madrone.desktop:
+  label: desktop
+  mediaQuery: '(min-width: 768px)'
+  weight: 2
+  multipliers:
+    - 1x
+    - 2x
+madrone.wide:
+  label: wide
+  mediaQuery: '(min-width: 992px)'
+  weight: 3
+  multipliers:
+    - 1x
+    - 2x
+madrone.ultra_wide:
+  label: ultra wide
+  mediaQuery: '(min-width: 1200px)'
+  weight: 4
+  multipliers:
+    - 1x
+    - 2x
+madrone.xl:
+  label: xl
+  mediaQuery: '(min-width: 1400px)'
+  weight: 5
+  multipliers:
+    - 1x
+    - 2x

--- a/templates/paragraphs/paragraph--osu-accordion-section.html.twig
+++ b/templates/paragraphs/paragraph--osu-accordion-section.html.twig
@@ -48,7 +48,8 @@
 ] %}
 {# Sets Unique ID for Accordion from Paragraph ID. #}
 {% set paragraph_id = 'accordion-' ~ paragraph.id.value %}
-{% set accordion_header_element = paragraph.field_p_accordion_heading.value is not empty ? 'h3' : 'h2' %}
+{# this variable was used in a commit to try and provide symantically correct HTML headings. Twigcs is unhappy with it #}
+{# {% set accordion_header_element = paragraph.field_p_accordion_heading.value is not empty ? 'h3' : 'h2' %} #}
 
 {% block paragraph %}
   {% macro accordion_id(paragraph_id, key) %}


### PR DESCRIPTION
The commit introduces `madrone.breakpoints.yml` to specify display breakpoints for various screen sizes in the Madrone theme. The breakpoints include mobile, tablet, desktop, wide, ultra-wide, and xl sizes, each with respective media queries and multiplier values.