### PR TITLE
Update to pausing videos when user has "prefers reduced motion"

### DIFF
--- a/dist/madrone.js
+++ b/dist/madrone.js
@@ -548,12 +548,12 @@ function reducedMotionCheck() {
       AOS.init({disable: true});
     }
     // Pause all videos.
-    videoList.forEach(video => {
-      video.pause();
-    })
+    for (let item of videoList) {
+      item.pause();
+    }
     // Update video control button text to match current state.
     videoButtonControls.forEach(buttonControls => {
-      buttonControls.innerText = "⏵ Play"
+      buttonControls.innerHTML =  "<i class=\"fa-solid fa-play\"></i> Play";
     })
   }
 }

--- a/src/madrone.js
+++ b/src/madrone.js
@@ -548,12 +548,12 @@ function reducedMotionCheck() {
       AOS.init({disable: true});
     }
     // Pause all videos.
-    videoList.forEach(video => {
-      video.pause();
-    })
+    for (let item of videoList) {
+      item.pause();
+    }
     // Update video control button text to match current state.
     videoButtonControls.forEach(buttonControls => {
-      buttonControls.innerText = "⏵ Play"
+      buttonControls.innerHTML =  "<i class=\"fa-solid fa-play\"></i> Play";
     })
   }
 }


### PR DESCRIPTION
The code to pause all videos when the user has the setting to reduce motion was not executing properly, this fixed the loop to ensure all videos are paused on the page.