### PR TITLE
Update CSS URL in madrone.libraries.yml

### DIFF
--- a/madrone.libraries.yml
+++ b/madrone.libraries.yml
@@ -22,4 +22,4 @@ fonts:
   css:
     theme:
       '//fonts.googleapis.com/css?family=Open Sans:300,400,500,600,700': { type: external }
-      '//cdn.icomoon.io/155267/OregonStateBrandIcons/style-cf.css?8rsof6': { type: external, minified: false }
+      '//cdn.icomoon.io/155267/OregonStateBrandIcons/style-cf.css?6642o2': { type: external, minified: false }


### PR DESCRIPTION
Update the URL for OregonStateBrandIcons stylesheet in the library configuration file. This ensures the theme is loading the correct and updated external CSS resource.