### PR TITLE
Add iCal export icon and wrap feed icons in a container

### DIFF
--- a/templates/views/date-ical-icon.html.twig
+++ b/templates/views/date-ical-icon.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Default theme implementation for an export icon.
+ *
+ * Available variables:
+ * - url: An internal system path of the data export.
+ * - attributes: Remaining HTML attributes for the export link.
+ *   - format: The export format (csv, json, xml).
+ *   - class: HTML classes to be applied to the export link.
+ *
+ * @ingroup themeable
+ */
+#}
+<a href="{{ url }}"{{ attributes.addClass('icon-link icon-link-hover') }}>
+  <i class="fa-regular fa-calendar-days"></i> {{ title }}
+</a>

--- a/templates/views/views-view.html.twig
+++ b/templates/views/views-view.html.twig
@@ -63,5 +63,9 @@
     </footer>
   {% endif %}
 
-  {{ feed_icons }}
+  {% if feed_icons %}
+    <div class="feed-icons">
+      {{ feed_icons }}
+    </div>
+  {% endif %}
 </div>


### PR DESCRIPTION
Introduce a new template for rendering an iCal export icon with customizable attributes and styling. Additionally, wrap feed icons with a container div for better structure and styling consistency.