### PR TITLE
Add new page layout template: page--shurly.html.twig

### DIFF
--- a/templates/layout/page--shurly.html.twig
+++ b/templates/layout/page--shurly.html.twig
@@ -1,0 +1,87 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+<div class="layout-container min-vh-100 d-flex flex-column">
+
+  <header class="container-fluid osu-bg-page-alt-1 g-0" role="banner">
+    {{ page.header }}
+  </header>
+
+  {{ page.primary_menu }}
+  {{ page.full_top }}
+  {{ page.breadcrumb }}
+  {{ page.highlighted }}
+  {{ page.help }}
+
+  {% set page_sidebar_content = page.sidebar|render|striptags('<img><video><drupal-render-placeholder>')|trim is not empty %}
+
+  {% set content_classes = [
+    'layout-content',
+    page_sidebar_content ? 'col-12 col-lg-9' : 'col-12'
+  ] %}
+  <div class="container flex-fill position-relative">
+    <main class="d-flex flex-wrap flex-fill gx-3 gx-lg-0" role="main">
+      <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+      <div{{ content_attributes.addClass(content_classes) }}>
+        {{ page.content }}
+      </div>
+
+      {% if page_sidebar_content %}
+        <aside class="layout-sidebar px-4 px-lg-2 px-xxl-3 col-12 col-lg-3 flex-fill"
+               role="complementary">
+          {{ page.sidebar }}
+        </aside>
+      {% endif %}
+    </main>
+  </div>
+  {{ page.pre_footer }}
+
+  <footer class="container-fluid g-0 mt-auto" role="contentinfo">
+    {{ page.footer }}
+  </footer>
+
+
+</div>{# /.layout-container #}


### PR DESCRIPTION
This commit introduces a new layout template for 'shurly' pages in the application. It includes a detailed list of available variables like 'base_path', 'logged_in', 'page.header', 'page.content', etc. and the structure of the page. The layout consists of various elements such as headers, main content, sidebars, and footer, and includes conditional rendering for sidebar content.