### PR TITLE
Improve accessibility and refine message layout

### DIFF
--- a/dist/messages.js
+++ b/dist/messages.js
@@ -51,13 +51,13 @@
 
     messageWrapper.innerHTML = `
     <div class="messages__header">
-      <h2 id="${id}-title" class="messages__title">
+      <h2 class="messages__title visually-hidden" id="${id}-title">
         ${messagesTypes[type]}
       </h2>
     </div>
-    <div class="messages__content d-flex align-items-center">
-    <i class="${alertIconClass} me-2"></i>
-      ${text}
+    <div class="messages__content d-flex gap-2 align-items-center">
+    <i class="${alertIconClass}"></i>
+      <span>${text}</span>
     </div>
     <button aria-label="Close" class="btn-close" data-bs-dismiss="alert" type="button"></button>
   `;

--- a/src/messages.js
+++ b/src/messages.js
@@ -51,13 +51,13 @@
 
     messageWrapper.innerHTML = `
     <div class="messages__header">
-      <h2 id="${id}-title" class="messages__title">
+      <h2 class="messages__title visually-hidden" id="${id}-title">
         ${messagesTypes[type]}
       </h2>
     </div>
-    <div class="messages__content d-flex align-items-center">
-    <i class="${alertIconClass} me-2"></i>
-      ${text}
+    <div class="messages__content d-flex gap-2 align-items-center">
+    <i class="${alertIconClass}"></i>
+      <span>${text}</span>
     </div>
     <button aria-label="Close" class="btn-close" data-bs-dismiss="alert" type="button"></button>
   `;

--- a/templates/block/block--system-messages-block.html.twig
+++ b/templates/block/block--system-messages-block.html.twig
@@ -8,6 +8,8 @@
  *
  * Available variables:
  * - content: The content of this block.
+ *
+ * @ingroup themeable
  */
 #}
 {{ content }}

--- a/templates/misc/status-messages.html.twig
+++ b/templates/misc/status-messages.html.twig
@@ -45,9 +45,9 @@
       'error': 'fas fa-2x fa-times-circle',
     } %}
     {% set icon_wrapper_classes = {
-      'status': 'd-flex align-items-center',
-      'warning': 'd-flex align-items-center',
-      'error': 'd-flex align-items-center',
+      'status': 'd-flex gap-2 align-items-center',
+      'warning': 'd-flex gap-2 align-items-center',
+      'error': 'd-flex gap-2 align-items-center',
     } %}
     <div
       aria-label="{{ status_headings[type] }}"{{ attributes.addClass(status_classes, status_colors[type], dismiss_class)|without('role', 'aria-label').setAttribute('role', role[type]) }}>
@@ -57,7 +57,6 @@
       <div
         class="{{ icon_wrapper_classes[type] }}">
         <i class="{{ icon_classes[type] }}"></i>
-
         {% if messages|length > 1 %}
           <ul>
             {% for message in messages %}
@@ -65,7 +64,7 @@
             {% endfor %}
           </ul>
         {% else %}
-          <p class="mb-0 ms-2">{{ messages|first }}</p>
+          <span>{{ messages|first }}</span>
         {% endif %}
       </div>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>


### PR DESCRIPTION
Added `visually-hidden` class to message titles for better screen reader support. Adjusted layout for spacing consistency by adding `gap-2` and replacing `<p>` with `<span>` for single messages.