### PR TITLE
Fix Kaltura iframe overflow issue

### DIFF
--- a/dist/madrone.js
+++ b/dist/madrone.js
@@ -146,6 +146,8 @@ window.addEventListener('load', () => {
   document.querySelectorAll('.media--type-kaltura iframe.media-oembed-content').forEach(iframe => {
     if (iframe.contentWindow && iframe.contentWindow.document.readyState === 'complete') {
       const iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+      // Add overflow hidden to Kaltura player iframe
+      iframeDocument.documentElement.style.cssText = "overflow: hidden;";
       const kalturaPlayerIframe = iframeDocument.querySelector('iframe#kaltura_player');
       if (kalturaPlayerIframe) {
         kalturaPlayerIframe.style.cssText = 'position: absolute; inset: 0; width: 100%; height: 100%; margin: 0;';

--- a/src/madrone.js
+++ b/src/madrone.js
@@ -146,6 +146,8 @@ window.addEventListener('load', () => {
   document.querySelectorAll('.media--type-kaltura iframe.media-oembed-content').forEach(iframe => {
     if (iframe.contentWindow && iframe.contentWindow.document.readyState === 'complete') {
       const iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+      // Add overflow hidden to Kaltura player iframe
+      iframeDocument.documentElement.style.cssText = "overflow: hidden;";
       const kalturaPlayerIframe = iframeDocument.querySelector('iframe#kaltura_player');
       if (kalturaPlayerIframe) {
         kalturaPlayerIframe.style.cssText = 'position: absolute; inset: 0; width: 100%; height: 100%; margin: 0;';


### PR DESCRIPTION
Added a CSS rule to set `overflow: hidden` on the iframe document element of Kaltura media players. This ensures proper content clipping and prevents visual overflow in embedded players.